### PR TITLE
drivers: remove advisory locks

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -17,8 +17,6 @@ type Driver interface {
 	// Close closes the underlying db connection. If the driver is created via Open() function
 	// this method will also going to call Close() on the sql.db instance.
 	Close() error
-	Lock() error
-	Unlock() error
 	Apply(migration *models.Migration, saveVersion bool) error
 	AppliedMigrations() ([]*models.Migration, error)
 	SetConfig(key string, value interface{}) error

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -131,74 +131,6 @@ func (driver *mysql) Close() error {
 	return nil
 }
 
-func (driver *mysql) Lock() error {
-	if drivers.IsLockable(driver) {
-		// Supports lockable, so already locked at the global level.
-		return nil
-	}
-
-	aid, err := drivers.GenerateAdvisoryLockID(driver.config.databaseName, driver.config.MigrationsTable)
-	if err != nil {
-		return err
-	}
-
-	// This will wait until the lock can be acquired or until the statement timeout has reached.
-	query := fmt.Sprintf("SELECT GET_LOCK(?, %d)", driver.config.StatementTimeoutInSecs)
-	var success bool
-	ctx, cancel := drivers.GetContext(driver.config.StatementTimeoutInSecs)
-	defer cancel()
-
-	if err := driver.conn.QueryRowContext(ctx, query, aid).Scan(&success); err != nil {
-		return &drivers.DatabaseError{
-			OrigErr: err,
-			Driver:  driverName,
-			Message: "failed to obtain advisory lock due to error",
-			Command: "lock_migrations_table",
-			Query:   []byte(query),
-		}
-	}
-
-	if !success {
-		return &drivers.DatabaseError{
-			OrigErr: err,
-			Driver:  driverName,
-			Message: "failed to obtain advisory lock, potentially due to timeout",
-			Command: "lock_migrations_table",
-			Query:   []byte(query),
-		}
-	}
-
-	return nil
-}
-
-func (driver *mysql) Unlock() error {
-	if drivers.IsLockable(driver) {
-		// Supports lockable, so already locked at the global level.
-		return nil
-	}
-
-	aid, err := drivers.GenerateAdvisoryLockID(driver.config.databaseName, driver.config.MigrationsTable)
-	if err != nil {
-		return err
-	}
-
-	query := `SELECT RELEASE_LOCK(?)`
-	ctx, cancel := drivers.GetContext(driver.config.StatementTimeoutInSecs)
-	defer cancel()
-
-	if _, err := driver.conn.ExecContext(ctx, query, aid); err != nil {
-		return &drivers.DatabaseError{
-			OrigErr: err,
-			Driver:  driverName,
-			Message: "failed to unlock advisory lock",
-			Command: "unlock_migrations_table",
-			Query:   []byte(query),
-		}
-	}
-
-	return nil
-}
-
 func (driver *mysql) createSchemaTableIfNotExists() (err error) {
 	ctx, cancel := drivers.GetContext(driver.config.StatementTimeoutInSecs)
 	defer cancel()
@@ -218,17 +150,6 @@ func (driver *mysql) createSchemaTableIfNotExists() (err error) {
 }
 
 func (driver *mysql) Apply(migration *models.Migration, saveVersion bool) (err error) {
-	if err = driver.Lock(); err != nil {
-		return err
-	}
-	defer func() {
-		// If we saw no error prior to unlocking and unlocking returns an error we need to
-		// assign the unlocking error to err
-		if unlockErr := driver.Unlock(); unlockErr != nil && err == nil {
-			err = unlockErr
-		}
-	}()
-
 	query, readErr := migration.Query()
 	if readErr != nil {
 		return &drivers.AppError{
@@ -280,17 +201,6 @@ func (driver *mysql) AppliedMigrations() (migrations []*models.Migration, err er
 			Driver:  driverName,
 		}
 	}
-
-	if err = driver.Lock(); err != nil {
-		return nil, err
-	}
-	defer func() {
-		// If we saw no error prior to unlocking and unlocking returns an error we need to
-		// assign the unlocking error to err
-		if unlockErr := driver.Unlock(); unlockErr != nil && err == nil {
-			err = unlockErr
-		}
-	}()
 
 	if err := driver.createSchemaTableIfNotExists(); err != nil {
 		return nil, err

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -196,27 +196,6 @@ func (suite *MysqlTestSuite) TestCreateSchemaTableIfNotExists() {
 	})
 }
 
-func (suite *MysqlTestSuite) TestUnlock() {
-	defaultConfig := getDefaultConfig()
-
-	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
-	defer teardown()
-
-	err := connectedDriver.Lock()
-	suite.Require().NoError(err, "should not error when attempting to acquire an advisory lock")
-
-	advisoryLockID, err := drivers.GenerateAdvisoryLockID("morph_test", defaultConfig.MigrationsTable)
-	suite.Require().NoError(err, "should not error when generating generate advisory lock id")
-
-	err = connectedDriver.Unlock()
-	suite.Require().NoError(err, "should not error when attempting to release an advisory lock")
-
-	var result int
-	err = suite.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE = 'USER LEVEL LOCK' AND LOCK_STATUS = 'GRANTED' AND OBJECT_NAME = '%s'", advisoryLockID)).Scan(&result)
-	suite.Require().NoError(err, "should not error querying performance_schema.metadata_locks")
-	suite.Require().Equal(0, result, "advisory lock should be released")
-}
-
 func (suite *MysqlTestSuite) TestAppliedMigrations() {
 	defaultConfig := getDefaultConfig()
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -219,75 +219,7 @@ func (pg *postgres) Close() error {
 	return nil
 }
 
-func (pg *postgres) Lock() error {
-	if drivers.IsLockable(pg) {
-		// Supports lockable, so already locked at the global level.
-		return nil
-	}
-
-	aid, err := drivers.GenerateAdvisoryLockID(pg.config.databaseName, pg.config.schemaName)
-	if err != nil {
-		return err
-	}
-
-	// This will wait until the lock can be acquired or until the statement timeout has reached.
-	query := "SELECT pg_advisory_lock($1)"
-	ctx, cancel := drivers.GetContext(pg.config.StatementTimeoutInSecs)
-	defer cancel()
-
-	if _, err := pg.conn.ExecContext(ctx, query, aid); err != nil {
-		return &drivers.DatabaseError{
-			OrigErr: err,
-			Driver:  driverName,
-			Message: "failed to obtain advisory lock",
-			Command: "lock_migrations_table",
-			Query:   []byte(query),
-		}
-	}
-
-	return nil
-}
-
-func (pg *postgres) Unlock() error {
-	if drivers.IsLockable(pg) {
-		// Supports lockable, so already locked at the global level.
-		return nil
-	}
-
-	aid, err := drivers.GenerateAdvisoryLockID(pg.config.databaseName, pg.config.schemaName)
-	if err != nil {
-		return err
-	}
-
-	query := "SELECT pg_advisory_unlock($1)"
-	ctx, cancel := drivers.GetContext(pg.config.StatementTimeoutInSecs)
-	defer cancel()
-
-	if _, err := pg.conn.ExecContext(ctx, query, aid); err != nil {
-		return &drivers.DatabaseError{
-			OrigErr: err,
-			Driver:  driverName,
-			Message: "failed to unlock advisory lock",
-			Command: "unlock_migrations_table",
-			Query:   []byte(query),
-		}
-	}
-
-	return nil
-}
-
 func (pg *postgres) Apply(migration *models.Migration, saveVersion bool) (err error) {
-	if err = pg.Lock(); err != nil {
-		return err
-	}
-	defer func() {
-		// If we saw no error prior to unlocking and unlocking returns an error we need to
-		// assign the unlocking error to err
-		if unlockErr := pg.Unlock(); unlockErr != nil && err == nil {
-			err = unlockErr
-		}
-	}()
-
 	query, readErr := migration.Query()
 	if readErr != nil {
 		return &drivers.AppError{
@@ -342,17 +274,6 @@ func (pg *postgres) AppliedMigrations() (migrations []*models.Migration, err err
 			Driver:  driverName,
 		}
 	}
-
-	if err = pg.Lock(); err != nil {
-		return nil, err
-	}
-	defer func() {
-		// If we saw no error prior to unlocking and unlocking returns an error we need to
-		// assign the unlocking error to err
-		if unlockErr := pg.Unlock(); unlockErr != nil && err == nil {
-			err = unlockErr
-		}
-	}()
 
 	if err := pg.createSchemaTableIfNotExists(); err != nil {
 		return nil, err

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -202,25 +202,6 @@ func (suite *PostgresTestSuite) TestCreateSchemaTableIfNotExists() {
 	})
 }
 
-func (suite *PostgresTestSuite) TestUnlock() {
-	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
-	defer teardown()
-
-	err := connectedDriver.Lock()
-	suite.Require().NoError(err, "should not error when attempting to acquire an advisory lock")
-
-	advisoryLockID, err := drivers.GenerateAdvisoryLockID("morph_test", "public")
-	suite.Require().NoError(err, "should not error when generating generate advisory lock id")
-
-	err = connectedDriver.Unlock()
-	suite.Require().NoError(err, "should not error when attempting to release an advisory lock")
-
-	var result int
-	err = suite.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND objid = '%s'", advisoryLockID)).Scan(&result)
-	suite.Require().NoError(err, "should not error querying pg_locks")
-	suite.Require().Equal(0, result, "advisory lock should be released")
-}
-
 func (suite *PostgresTestSuite) TestAppliedMigrations() {
 	defaultConfig := getDefaultConfig()
 


### PR DESCRIPTION

#### Summary
We can remove the advisory locks, it was already a detail in the driver implementation after introducing our own locks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41673

