### PR TITLE
[MM-41987] skip applied migrations test

### DIFF
--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -153,6 +153,8 @@ func (suite *SqliteTestSuite) TestUnlock() {
 }
 
 func (suite *SqliteTestSuite) TestAppliedMigrations() {
+	suite.T().Skip("MM-41987")
+
 	connectedDriver, teardown := suite.InitializeDriver(defaultConnURL)
 	defer teardown()
 


### PR DESCRIPTION
#### Summary
The `TestAppliedMigrations` for sqlite is triggering some weird data race on the CI machine. Couldn't reproduce locally, skipping it for now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41987
