### PR TITLE
Make sqlite driver lock methods unexported

### DIFF
--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -132,7 +132,7 @@ func (driver *sqlite) Close() error {
 	return nil
 }
 
-func (driver *sqlite) Lock() error {
+func (driver *sqlite) lock() error {
 	if !atomic.CompareAndSwapInt32(&driver.lockedFlag, 0, 1) {
 		return &drivers.DatabaseError{
 			OrigErr: errors.New("already locked"),
@@ -145,7 +145,7 @@ func (driver *sqlite) Lock() error {
 	return nil
 }
 
-func (driver *sqlite) Unlock() error {
+func (driver *sqlite) unlock() error {
 	atomic.StoreInt32(&driver.lockedFlag, 0)
 
 	return nil
@@ -170,11 +170,11 @@ func (driver *sqlite) createSchemaTableIfNotExists() (err error) {
 }
 
 func (driver *sqlite) Apply(migration *models.Migration, saveVersion bool) (err error) {
-	if err = driver.Lock(); err != nil {
+	if err = driver.lock(); err != nil {
 		return err
 	}
 	defer func() {
-		_ = driver.Unlock()
+		_ = driver.unlock()
 	}()
 
 	query, readErr := migration.Query()
@@ -232,11 +232,11 @@ func (driver *sqlite) AppliedMigrations() (migrations []*models.Migration, err e
 		}
 	}
 
-	if err = driver.Lock(); err != nil {
+	if err = driver.lock(); err != nil {
 		return nil, err
 	}
 	defer func() {
-		_ = driver.Unlock()
+		_ = driver.unlock()
 	}()
 
 	if err := driver.createSchemaTableIfNotExists(); err != nil {

--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -130,11 +130,14 @@ func (suite *SqliteTestSuite) TestLock() {
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
-	err := connectedDriver.Lock()
-	suite.Require().NoError(err, "should not error when attempting to acquire a lock")
-	defer func() { suite.Require().NoError(connectedDriver.Unlock()) }()
+	driver, ok := connectedDriver.(*sqlite)
+	suite.Require().True(ok)
 
-	err = connectedDriver.Lock()
+	err := driver.lock()
+	suite.Require().NoError(err, "should not error when attempting to acquire a lock")
+	defer func() { suite.Require().NoError(driver.unlock()) }()
+
+	err = driver.lock()
 	suite.Require().Error(err, "should error when attempting to acquire a lock if driver is locked")
 }
 
@@ -142,13 +145,16 @@ func (suite *SqliteTestSuite) TestUnlock() {
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
-	err := connectedDriver.Lock()
+	driver, ok := connectedDriver.(*sqlite)
+	suite.Require().True(ok)
+
+	err := driver.lock()
 	suite.Require().NoError(err, "should not error when attempting to acquire a lock")
 
-	err = connectedDriver.Unlock()
+	err = driver.unlock()
 	suite.Require().NoError(err, "should not error when attempting to release a lock")
 
-	err = connectedDriver.Unlock()
+	err = driver.unlock()
 	suite.Require().NoError(err, "should not error when attempting to release an unlocked driver")
 }
 


### PR DESCRIPTION

#### Summary
Fixes a merge defect and unexports the locking methods for sqlite.


