### PR TITLE
drivers/lock: remove LockWithContext method and use Lock with a context

### DIFF
--- a/drivers/lock.go
+++ b/drivers/lock.go
@@ -63,14 +63,13 @@ func NextWaitInterval(lastWaitInterval time.Duration, err error) time.Duration {
 }
 
 type Locker interface {
-	Lock() error
-	Unlock() error
-	// LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
+	// Lock locks m unless the context is canceled. If the mutex is already locked by any other
 	// instance, including the current one, the calling goroutine blocks until the mutex can be locked,
 	// or the context is canceled.
 	//
 	// The mutex is locked only if a nil error is returned.
-	LockWithContext(ctx context.Context) error
+	Lock(ctx context.Context) error
+	Unlock() error
 }
 
 type Lockable interface {

--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -167,18 +167,12 @@ func (m *Mutex) refreshLock(ctx context.Context) error {
 	return nil
 }
 
-// Lock locks m. If the mutex is already locked by any other morph instance, including the current one,
-// the calling goroutine blocks until the mutex can be locked.
-func (m *Mutex) Lock() error {
-	return m.LockWithContext(context.Background())
-}
-
-// LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
+// Lock locks m unless the context is canceled. If the mutex is already locked by any other
 // instance, including the current one, the calling goroutine blocks until the mutex can be locked,
 // or the context is canceled.
 //
 // The mutex is locked only if a nil error is returned.
-func (m *Mutex) LockWithContext(ctx context.Context) error {
+func (m *Mutex) Lock(ctx context.Context) error {
 	var waitInterval time.Duration
 
 	for {

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -167,18 +167,12 @@ func (m *Mutex) refreshLock(ctx context.Context) error {
 	return nil
 }
 
-// Lock locks m. If the mutex is already locked by any other morph instance, including the current one,
-// the calling goroutine blocks until the mutex can be locked.
-func (m *Mutex) Lock() error {
-	return m.LockWithContext(context.Background())
-}
-
-// LockWithContext locks m unless the context is canceled. If the mutex is already locked by any other
+// Lock locks m unless the context is canceled. If the mutex is already locked by any other
 // instance, including the current one, the calling goroutine blocks until the mutex can be locked,
 // or the context is canceled.
 //
 // The mutex is locked only if a nil error is returned.
-func (m *Mutex) LockWithContext(ctx context.Context) error {
+func (m *Mutex) Lock(ctx context.Context) error {
 	var waitInterval time.Duration
 
 	for {

--- a/morph.go
+++ b/morph.go
@@ -110,7 +110,7 @@ func New(ctx context.Context, driver drivers.Driver, source sources.Source, opti
 		}
 
 		engine.mutex = mx
-		err = mx.LockWithContext(ctx)
+		err = mx.Lock(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Summary
A small simplification in the `drivers.Locker` interface, we don't use the Lock w/o a `context.Context` so, it would be better to remove it to avoid confusion.

