### PR TITLE
sources/embedded: avoid using filepath.Join

### DIFF
--- a/sources/embedded/embedded_test.go
+++ b/sources/embedded/embedded_test.go
@@ -38,7 +38,7 @@ func TestGoEmbed(t *testing.T) {
 	}
 
 	s := Resource(assetNames, func(name string) ([]byte, error) {
-		return assets.ReadFile(strings.Join([]string{"testfiles", name}, "/"))
+		return assets.ReadFile("testfiles/" + name)
 	})
 
 	src, err := WithInstance(s)

--- a/sources/embedded/embedded_test.go
+++ b/sources/embedded/embedded_test.go
@@ -5,7 +5,7 @@ package embedded
 
 import (
 	"embed"
-	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/morph/sources/embedded/testdata"
@@ -38,7 +38,7 @@ func TestGoEmbed(t *testing.T) {
 	}
 
 	s := Resource(assetNames, func(name string) ([]byte, error) {
-		return assets.ReadFile(filepath.Join("testfiles", name))
+		return assets.ReadFile(strings.Join([]string{"testfiles", name}, "/"))
 	})
 
 	src, err := WithInstance(s)

--- a/sources/embedded/embedded_test.go
+++ b/sources/embedded/embedded_test.go
@@ -5,7 +5,6 @@ package embedded
 
 import (
 	"embed"
-	"strings"
 	"testing"
 
 	"github.com/mattermost/morph/sources/embedded/testdata"


### PR DESCRIPTION
#### Summary
`go: embed` uses file separators as `/` even in Windows. From the [docs](https://pkg.go.dev/embed#hdr-Directives):

> The //go:embed directive accepts multiple space-separated patterns for brevity, but it can also be repeated, to avoid very long lines when there are many patterns. The patterns are interpreted relative to the package directory containing the source file. The path separator is a forward slash, even on Windows systems



