### PR TITLE
sources: remove open and close methods from interface

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -9,11 +9,11 @@ import (
 	"github.com/mattermost/morph/drivers/mysql"
 	"github.com/mattermost/morph/drivers/postgres"
 	"github.com/mattermost/morph/drivers/sqlite"
-	"github.com/mattermost/morph/sources"
+	"github.com/mattermost/morph/sources/file"
 )
 
-func Migrate(ctx context.Context, dsn, source, driverName, path string, options ...morph.EngineOption) error {
-	engine, err := initializeEngine(ctx, dsn, source, driverName, path, options...)
+func Migrate(ctx context.Context, dsn, driverName, path string, options ...morph.EngineOption) error {
+	engine, err := initializeEngine(ctx, dsn, driverName, path, options...)
 	if err != nil {
 		return err
 	}
@@ -22,8 +22,8 @@ func Migrate(ctx context.Context, dsn, source, driverName, path string, options 
 	return engine.ApplyAll()
 }
 
-func Up(ctx context.Context, limit int, dsn, source, driverName, path string, options ...morph.EngineOption) (int, error) {
-	engine, err := initializeEngine(ctx, dsn, source, driverName, path, options...)
+func Up(ctx context.Context, limit int, dsn, driverName, path string, options ...morph.EngineOption) (int, error) {
+	engine, err := initializeEngine(ctx, dsn, driverName, path, options...)
 	if err != nil {
 		return -1, err
 	}
@@ -32,8 +32,8 @@ func Up(ctx context.Context, limit int, dsn, source, driverName, path string, op
 	return engine.Apply(limit)
 }
 
-func Down(ctx context.Context, limit int, dsn, source, driverName, path string, options ...morph.EngineOption) (int, error) {
-	engine, err := initializeEngine(ctx, dsn, source, driverName, path, options...)
+func Down(ctx context.Context, limit int, dsn, driverName, path string, options ...morph.EngineOption) (int, error) {
+	engine, err := initializeEngine(ctx, dsn, driverName, path, options...)
 	if err != nil {
 		return -1, err
 	}
@@ -42,12 +42,11 @@ func Down(ctx context.Context, limit int, dsn, source, driverName, path string, 
 	return engine.ApplyDown(limit)
 }
 
-func initializeEngine(ctx context.Context, dsn, source, driverName, path string, options ...morph.EngineOption) (*morph.Morph, error) {
-	src, err := sources.Open(source, path)
+func initializeEngine(ctx context.Context, dsn, driverName, path string, options ...morph.EngineOption) (*morph.Morph, error) {
+	src, err := file.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	defer src.Close()
 
 	var driver drivers.Driver
 	switch driverName {

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -19,7 +19,6 @@ func ApplyCmd() *cobra.Command {
 	cmd.PersistentFlags().String("dsn", "", "the dsn of the database")
 	_ = cmd.MarkPersistentFlagRequired("dsn")
 
-	cmd.PersistentFlags().StringP("source", "s", "file", "the source of the migrations")
 	cmd.PersistentFlags().StringP("path", "p", "", "the source path of the migrations")
 	_ = cmd.MarkPersistentFlagRequired("path")
 
@@ -72,7 +71,6 @@ func MigrateApplyCmd() *cobra.Command {
 
 func upApplyCmdF(cmd *cobra.Command, _ []string) error {
 	dsn, _ := cmd.Flags().GetString("dsn")
-	source, _ := cmd.Flags().GetString("source")
 	driverName, _ := cmd.Flags().GetString("driver")
 	path, _ := cmd.Flags().GetString("path")
 	steps, _ := cmd.Flags().GetInt("number")
@@ -83,7 +81,7 @@ func upApplyCmdF(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	morph.InfoLogger.Printf("Attempting to apply %d migrations...\n", steps)
-	n, err := apply.Up(ctx, steps, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
+	n, err := apply.Up(ctx, steps, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
 	if n > 0 {
 		morph.SuccessLogger.Printf("%d migrations applied.\n", n)
 	} else if n == 0 {
@@ -94,7 +92,6 @@ func upApplyCmdF(cmd *cobra.Command, _ []string) error {
 
 func downApplyCmdF(cmd *cobra.Command, _ []string) error {
 	dsn, _ := cmd.Flags().GetString("dsn")
-	source, _ := cmd.Flags().GetString("source")
 	driverName, _ := cmd.Flags().GetString("driver")
 	path, _ := cmd.Flags().GetString("path")
 	steps, _ := cmd.Flags().GetInt("number")
@@ -105,7 +102,7 @@ func downApplyCmdF(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	morph.InfoLogger.Printf("Attempting to apply  %d migrations...\n", steps)
-	n, err := apply.Down(ctx, steps, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
+	n, err := apply.Down(ctx, steps, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
 	if n > 0 {
 		morph.SuccessLogger.Printf("%d migrations applied.\n", n)
 	} else if n == 0 {
@@ -116,7 +113,6 @@ func downApplyCmdF(cmd *cobra.Command, _ []string) error {
 
 func migrateApplyCmdF(cmd *cobra.Command, _ []string) error {
 	dsn, _ := cmd.Flags().GetString("dsn")
-	source, _ := cmd.Flags().GetString("source")
 	driverName, _ := cmd.Flags().GetString("driver")
 	path, _ := cmd.Flags().GetString("path")
 	timeout, _ := cmd.Flags().GetInt("timeout")
@@ -126,7 +122,7 @@ func migrateApplyCmdF(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	morph.InfoLogger.Println("Applying all pending migrations...")
-	if err := apply.Migrate(ctx, dsn, source, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey)); err != nil {
+	if err := apply.Migrate(ctx, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey)); err != nil {
 		return err
 	}
 	morph.SuccessLogger.Println("Pending migrations applied.")

--- a/sources/embedded/embedded.go
+++ b/sources/embedded/embedded.go
@@ -23,17 +23,9 @@ type AssetSource struct {
 	AssetFunc AssetFunc
 }
 
-func init() {
-	sources.Register("embedded", &Embedded{})
-}
-
 type Embedded struct {
 	assetSource *AssetSource
 	migrations  []*models.Migration
-}
-
-func (b *Embedded) Open(url string) (sources.Source, error) {
-	return nil, fmt.Errorf("not implemented")
 }
 
 func WithInstance(assetSource *AssetSource) (sources.Source, error) {
@@ -57,10 +49,6 @@ func WithInstance(assetSource *AssetSource) (sources.Source, error) {
 	}
 
 	return b, nil
-}
-
-func (b *Embedded) Close() error {
-	return nil
 }
 
 func (b *Embedded) Migrations() []*models.Migration {

--- a/sources/file/file.go
+++ b/sources/file/file.go
@@ -7,12 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/mattermost/morph/models"
-	"github.com/mattermost/morph/sources"
 )
-
-func init() {
-	sources.Register("file", &File{})
-}
 
 type File struct {
 	url        string
@@ -20,7 +15,7 @@ type File struct {
 	migrations []*models.Migration
 }
 
-func (f *File) Open(sourceURL string) (sources.Source, error) {
+func Open(sourceURL string) (*File, error) {
 	uri, err := url.Parse(sourceURL)
 	if err != nil {
 		return nil, err
@@ -93,10 +88,6 @@ func (f *File) readMigrations() error {
 	}
 
 	f.migrations = migrations
-	return nil
-}
-
-func (f *File) Close() error {
 	return nil
 }
 

--- a/sources/file/file_test.go
+++ b/sources/file/file_test.go
@@ -17,7 +17,7 @@ func TestFile(t *testing.T) {
 
 	t.Run("should correctly create a source with the testfiles", func(t *testing.T) {
 		sourceURL := "file://" + testFilesDir
-		f, err := (&File{}).Open(sourceURL)
+		f, err := Open(sourceURL)
 		require.NoError(t, err)
 
 		testlib.Test(t, f)
@@ -27,7 +27,7 @@ func TestFile(t *testing.T) {
 		absTestFilesDir, err := filepath.Abs(testFilesDir)
 		require.NoError(t, err)
 
-		f, err := (&File{}).Open(absTestFilesDir)
+		f, err := Open(absTestFilesDir)
 		require.NoError(t, err)
 
 		testlib.Test(t, f)

--- a/sources/source.go
+++ b/sources/source.go
@@ -1,47 +1,9 @@
 package sources
 
 import (
-	"fmt"
-	"sync"
-
 	"github.com/mattermost/morph/models"
 )
 
-var sourcesMu sync.RWMutex
-var registeredSources = make(map[string]Source)
-
 type Source interface {
-	Open(sourceURL string) (source Source, err error)
-	Close() (err error)
 	Migrations() (migrations []*models.Migration)
-}
-
-func Register(name string, source Source) {
-	sourcesMu.Lock()
-	defer sourcesMu.Unlock()
-
-	registeredSources[name] = source
-}
-
-func List() []string {
-	sourcesMu.Lock()
-	defer sourcesMu.Unlock()
-
-	sources := make([]string, 0, len(registeredSources))
-	for source := range registeredSources {
-		sources = append(sources, source)
-	}
-
-	return sources
-}
-
-func Open(sourceName, sourceURL string) (Source, error) {
-	sourcesMu.RLock()
-	source, ok := registeredSources[sourceName]
-	sourcesMu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("unsupported source %q found", sourceName)
-	}
-
-	return source.Open(sourceURL)
 }


### PR DESCRIPTION

#### Summary
The blog post is giving fruits with lots of deletions :) We don't need the complicated logic for sources, we can simplfy it. 
