### PR TITLE
drivers/lock: bugfix on lock expiration

### DIFF
--- a/drivers/logger.go
+++ b/drivers/logger.go
@@ -1,0 +1,19 @@
+package drivers
+
+import "fmt"
+
+type Logger interface {
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}
+
+type DefaultLogger struct {
+}
+
+func (DefaultLogger) Printf(format string, v ...interface{}) {
+	fmt.Printf(format, v...)
+}
+
+func (DefaultLogger) Println(v ...interface{}) {
+	fmt.Println(v...)
+}

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -389,9 +391,11 @@ func (suite *MysqlTestSuite) TestLock() {
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
+	logger := log.New(os.Stderr, "", 0)
+
 	suite.T().Run("should create lock and unlock the mutex", func(t *testing.T) {
 		ctx := context.Background()
-		mx, err := NewMutex("test-lock-key", connectedDriver)
+		mx, err := NewMutex("test-lock-key", connectedDriver, logger)
 		suite.Require().NoError(err, "should not error while creating the mutex")
 
 		err = mx.Lock(ctx)
@@ -409,7 +413,7 @@ func (suite *MysqlTestSuite) TestLock() {
 		_, err := ms.conn.ExecContext(ctx, query, "test-lock-key", 1)
 		suite.Require().NoError(err, "should not error while manually inserting the mutex")
 
-		mx, err := NewMutex("test-lock-key", connectedDriver)
+		mx, err := NewMutex("test-lock-key", connectedDriver, logger)
 		suite.Require().NoError(err, "should not error while creating the mutex")
 
 		err = mx.Lock(ctx)
@@ -436,7 +440,7 @@ func (suite *MysqlTestSuite) TestLock() {
 			defer func() {
 				close(done)
 			}()
-			mx, err := NewMutex("test-lock-key", connectedDriver)
+			mx, err := NewMutex("test-lock-key", connectedDriver, logger)
 			suite.Require().NoError(err, "should not error while creating the mutex")
 
 			err = mx.Lock(ctx)

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -4,11 +4,13 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mattermost/morph/drivers"
 	"github.com/mattermost/morph/models"
@@ -381,4 +383,76 @@ func (suite *MysqlTestSuite) TestWithInstance() {
 
 func TestMysqlTestSuite(t *testing.T) {
 	suite.Run(t, new(MysqlTestSuite))
+}
+
+func (suite *MysqlTestSuite) TestLock() {
+	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
+	defer teardown()
+
+	suite.T().Run("should create lock and unlock the mutex", func(t *testing.T) {
+		ctx := context.Background()
+		mx, err := NewMutex("test-lock-key", connectedDriver)
+		suite.Require().NoError(err, "should not error while creating the mutex")
+
+		err = mx.Lock(ctx)
+		suite.Require().NoError(err, "should not error while locking the mutex")
+
+		err = mx.Unlock()
+		suite.Require().NoError(err, "should not error while unlocking the mutex")
+	})
+
+	suite.T().Run("should release the expired lock", func(t *testing.T) {
+		ctx := context.Background()
+
+		ms := connectedDriver.(*mysql)
+		query := fmt.Sprintf("INSERT INTO %s (Id, ExpireAt) VALUES (?, ?)", drivers.MutexTableName)
+		_, err := ms.conn.ExecContext(ctx, query, "test-lock-key", 1)
+		suite.Require().NoError(err, "should not error while manually inserting the mutex")
+
+		mx, err := NewMutex("test-lock-key", connectedDriver)
+		suite.Require().NoError(err, "should not error while creating the mutex")
+
+		err = mx.Lock(ctx)
+		suite.Require().NoError(err, "should not error while locking the mutex")
+
+		err = mx.Unlock()
+		suite.Require().NoError(err, "should not error while unlocking the mutex")
+	})
+
+	suite.T().Run("should refresh the lock after expired", func(t *testing.T) {
+		ctx := context.Background()
+
+		now := time.Now()
+		timeout := time.After(2 * drivers.TTL) // should not wait to drop the lock for 30s
+
+		ms := connectedDriver.(*mysql)
+		query := fmt.Sprintf("INSERT INTO %s (Id, ExpireAt) VALUES (?, ?)", drivers.MutexTableName)
+		// set expiration 2 seconds later
+		_, err := ms.conn.ExecContext(ctx, query, "test-lock-key", now.Add(2*time.Second).Unix())
+		suite.Require().NoError(err, "should not error while manually inserting the mutex")
+
+		done := make(chan struct{})
+		go func() {
+			defer func() {
+				close(done)
+			}()
+			mx, err := NewMutex("test-lock-key", connectedDriver)
+			suite.Require().NoError(err, "should not error while creating the mutex")
+
+			err = mx.Lock(ctx)
+			suite.Require().NoError(err, "should not error while locking the mutex")
+
+			// ensure we waited the lock to be expire
+			suite.Require().True(time.Now().After(now.Add(2 * time.Second)))
+
+			err = mx.Unlock()
+			suite.Require().NoError(err, "should not error while unlocking the mutex")
+		}()
+
+		select {
+		case <-timeout:
+			suite.Require().Fail("should have wait and release the lock")
+		case <-done:
+		}
+	})
 }

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -72,15 +72,14 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer m.finalizeTx(tx)
 
 	query := fmt.Sprintf("INSERT INTO %s (id, expireat) VALUES ($1, $2)", drivers.MutexTableName)
 	if _, err := tx.Exec(query, m.key, now.Add(drivers.TTL).Unix()); err != nil {
 		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
 			m.logger.Println("DB is locked, going to try acquire the lock if it is expired.")
 		}
-		if txErr := tx.Rollback(); txErr != nil {
-			return false, txErr
-		}
+		m.finalizeTx(tx)
 
 		err2 := m.releaseLock(ctx, now)
 		if err2 == nil { // lock has been released due to expiration
@@ -92,10 +91,6 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 
 	err = tx.Commit()
 	if err != nil {
-		if txErr := tx.Rollback(); txErr != nil {
-			return false, txErr
-		}
-
 		return false, err
 	}
 
@@ -107,6 +102,7 @@ func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
 	if err != nil {
 		return err
 	}
+	defer m.finalizeTx(tx)
 
 	e, err := m.getExpireAt(tx)
 	if err != nil {
@@ -114,10 +110,6 @@ func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
 	}
 
 	if t.Unix() < e {
-		if txErr := tx.Rollback(); txErr != nil {
-			return fmt.Errorf("could not rollback: %w", txErr)
-		}
-
 		return errors.New("could not release the lock")
 	}
 
@@ -128,10 +120,6 @@ func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
 
 	err = tx.Commit()
 	if err != nil {
-		if txErr := tx.Rollback(); txErr != nil {
-			return fmt.Errorf("could not rollback transaction: %w", txErr)
-		}
-
 		return fmt.Errorf("unable to set new expireat for mutex: %w", err)
 	}
 
@@ -143,10 +131,6 @@ func (m *Mutex) getExpireAt(tx *sql.Tx) (int64, error) {
 	query := fmt.Sprintf("SELECT expireat FROM %s WHERE id = $1", drivers.MutexTableName)
 	err := tx.QueryRow(query, m.key).Scan(&expireAt)
 	if err != nil {
-		if txErr := tx.Rollback(); txErr != nil {
-			return -1, fmt.Errorf("could not rollback: %w", txErr)
-		}
-
 		return -1, fmt.Errorf("failed to fetch mutex from db: %w", err)
 	}
 
@@ -159,6 +143,7 @@ func (m *Mutex) refreshLock(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer m.finalizeTx(tx)
 
 	e, err := m.getExpireAt(tx)
 	if err != nil {
@@ -173,10 +158,6 @@ func (m *Mutex) refreshLock(ctx context.Context) error {
 
 	err = tx.Commit()
 	if err != nil {
-		if txErr := tx.Rollback(); txErr != nil {
-			return fmt.Errorf("could not rollback: %w", txErr)
-		}
-
 		return fmt.Errorf("unable to refresh expireat for mutex: %w", err)
 	}
 
@@ -258,14 +239,16 @@ func (m *Mutex) Unlock() error {
 
 func executeTx(tx *sql.Tx, query string, args ...interface{}) error {
 	if _, err := tx.Exec(query, args...); err != nil {
-		if txErr := tx.Rollback(); txErr != nil {
-			return fmt.Errorf("could not rollback transaction: %w", txErr)
-		}
-
 		return err
 	}
 
 	return nil
+}
+
+func (m *Mutex) finalizeTx(tx *sql.Tx) {
+	if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+		m.logger.Printf("failed to rollback transaction: %s", err)
+	}
 }
 
 // noCopy may be embedded into structs which must not be copied

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -71,7 +71,11 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 
 	query := fmt.Sprintf("INSERT INTO %s (id, expireat) VALUES ($1, $2)", drivers.MutexTableName)
 	if _, err := tx.Exec(query, m.key, now.Add(drivers.TTL).Unix()); err != nil {
-		err2 := m.releaseLock(tx, now)
+		if txErr := tx.Rollback(); txErr != nil {
+			return false, txErr
+		}
+
+		err2 := m.releaseLock(ctx, now)
 		if err2 == nil { // lock has been released due to expiration
 			return true, nil
 		}
@@ -91,7 +95,12 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (m *Mutex) releaseLock(tx *sql.Tx, t time.Time) error {
+func (m *Mutex) releaseLock(ctx context.Context, t time.Time) error {
+	tx, err := m.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
 	e, err := m.getExpireAt(tx)
 	if err != nil {
 		return err

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,12 +27,14 @@ type Mutex struct {
 	stopRefresh chan bool
 	refreshDone chan bool
 	conn        *sql.Conn
+
+	logger drivers.Logger
 }
 
 // NewMutex creates a mutex with the given key name.
 //
 // returns error if key is empty.
-func NewMutex(key string, driver drivers.Driver) (*Mutex, error) {
+func NewMutex(key string, driver drivers.Driver, logger drivers.Logger) (*Mutex, error) {
 	key, err := drivers.MakeLockKey(key)
 	if err != nil {
 		return nil, err
@@ -56,8 +59,9 @@ func NewMutex(key string, driver drivers.Driver) (*Mutex, error) {
 	}
 
 	return &Mutex{
-		key:  key,
-		conn: conn,
+		key:    key,
+		conn:   conn,
+		logger: logger,
 	}, nil
 }
 
@@ -71,6 +75,9 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 
 	query := fmt.Sprintf("INSERT INTO %s (id, expireat) VALUES ($1, $2)", drivers.MutexTableName)
 	if _, err := tx.Exec(query, m.key, now.Add(drivers.TTL).Unix()); err != nil {
+		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+			m.logger.Println("DB is locked, going to try acquire the lock if it is expired.")
+		}
 		if txErr := tx.Rollback(); txErr != nil {
 			return false, txErr
 		}

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -397,9 +399,11 @@ func (suite *PostgresTestSuite) TestLock() {
 	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
 	defer teardown()
 
+	logger := log.New(os.Stderr, "", 0)
+
 	suite.T().Run("should create lock and unlock the mutex", func(t *testing.T) {
 		ctx := context.Background()
-		mx, err := NewMutex("test-lock-key", connectedDriver)
+		mx, err := NewMutex("test-lock-key", connectedDriver, logger)
 		suite.Require().NoError(err, "should not error while creating the mutex")
 
 		err = mx.Lock(ctx)
@@ -417,7 +421,7 @@ func (suite *PostgresTestSuite) TestLock() {
 		_, err := pq.conn.ExecContext(ctx, query, "test-lock-key", 1)
 		suite.Require().NoError(err, "should not error while manually inserting the mutex")
 
-		mx, err := NewMutex("test-lock-key", connectedDriver)
+		mx, err := NewMutex("test-lock-key", connectedDriver, logger)
 		suite.Require().NoError(err, "should not error while creating the mutex")
 
 		err = mx.Lock(ctx)
@@ -444,7 +448,7 @@ func (suite *PostgresTestSuite) TestLock() {
 			defer func() {
 				close(done)
 			}()
-			mx, err := NewMutex("test-lock-key", connectedDriver)
+			mx, err := NewMutex("test-lock-key", connectedDriver, logger)
 			suite.Require().NoError(err, "should not error while creating the mutex")
 
 			err = mx.Lock(ctx)

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -4,11 +4,13 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mattermost/morph/drivers"
 	"github.com/mattermost/morph/models"
@@ -389,4 +391,76 @@ func (suite *PostgresTestSuite) TestWithInstance() {
 
 func TestPostgresSuite(t *testing.T) {
 	suite.Run(t, new(PostgresTestSuite))
+}
+
+func (suite *PostgresTestSuite) TestLock() {
+	connectedDriver, teardown := suite.InitializeDriver(testConnURL)
+	defer teardown()
+
+	suite.T().Run("should create lock and unlock the mutex", func(t *testing.T) {
+		ctx := context.Background()
+		mx, err := NewMutex("test-lock-key", connectedDriver)
+		suite.Require().NoError(err, "should not error while creating the mutex")
+
+		err = mx.Lock(ctx)
+		suite.Require().NoError(err, "should not error while locking the mutex")
+
+		err = mx.Unlock()
+		suite.Require().NoError(err, "should not error while unlocking the mutex")
+	})
+
+	suite.T().Run("should release the expired lock", func(t *testing.T) {
+		ctx := context.Background()
+
+		pq := connectedDriver.(*postgres)
+		query := fmt.Sprintf("INSERT INTO %s (id, expireat) VALUES ($1, $2)", drivers.MutexTableName)
+		_, err := pq.conn.ExecContext(ctx, query, "test-lock-key", 1)
+		suite.Require().NoError(err, "should not error while manually inserting the mutex")
+
+		mx, err := NewMutex("test-lock-key", connectedDriver)
+		suite.Require().NoError(err, "should not error while creating the mutex")
+
+		err = mx.Lock(ctx)
+		suite.Require().NoError(err, "should not error while locking the mutex")
+
+		err = mx.Unlock()
+		suite.Require().NoError(err, "should not error while unlocking the mutex")
+	})
+
+	suite.T().Run("should refresh the lock after expired", func(t *testing.T) {
+		ctx := context.Background()
+
+		now := time.Now()
+		timeout := time.After(2 * drivers.TTL) // should not wait to drop the lock for 30s
+
+		pq := connectedDriver.(*postgres)
+		query := fmt.Sprintf("INSERT INTO %s (id, expireat) VALUES ($1, $2)", drivers.MutexTableName)
+		// set expiration 2 seconds later
+		_, err := pq.conn.ExecContext(ctx, query, "test-lock-key", now.Add(2*time.Second).Unix())
+		suite.Require().NoError(err, "should not error while manually inserting the mutex")
+
+		done := make(chan struct{})
+		go func() {
+			defer func() {
+				close(done)
+			}()
+			mx, err := NewMutex("test-lock-key", connectedDriver)
+			suite.Require().NoError(err, "should not error while creating the mutex")
+
+			err = mx.Lock(ctx)
+			suite.Require().NoError(err, "should not error while locking the mutex")
+
+			// ensure we waited the lock to be expire
+			suite.Require().True(time.Now().After(now.Add(2 * time.Second)))
+
+			err = mx.Unlock()
+			suite.Require().NoError(err, "should not error while unlocking the mutex")
+		}()
+
+		select {
+		case <-timeout:
+			suite.Require().Fail("should have wait and release the lock")
+		case <-done:
+		}
+	})
 }

--- a/morph.go
+++ b/morph.go
@@ -99,9 +99,9 @@ func New(ctx context.Context, driver drivers.Driver, source sources.Source, opti
 		var err error
 		switch impl.DriverName() {
 		case "mysql":
-			mx, err = ms.NewMutex(engine.config.LockKey, driver)
+			mx, err = ms.NewMutex(engine.config.LockKey, driver, engine.config.Logger)
 		case "postgres":
-			mx, err = ps.NewMutex(engine.config.LockKey, driver)
+			mx, err = ps.NewMutex(engine.config.LockKey, driver, engine.config.Logger)
 		default:
 			err = errors.New("driver does not support locking")
 		}


### PR DESCRIPTION
#### Summary
We were trying to run release lock query on a failed transaction, we rollback the first one and then start a new transaction for releasing the lock.

fixes: https://community-daily.mattermost.com/core/pl/b5jbbngtjigepqucah8ztndj4e

