### PR TITLE
fix an issue where a driver trying to re-apply a migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -81,7 +81,7 @@ func upApplyCmdF(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	morph.InfoLogger.Printf("Attempting to apply %d migrations...\n", steps)
-	n, err := apply.Up(ctx, steps, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
+	n, err := apply.Up(ctx, steps, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetStatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
 	if n > 0 {
 		morph.SuccessLogger.Printf("%d migrations applied.\n", n)
 	} else if n == 0 {
@@ -102,7 +102,7 @@ func downApplyCmdF(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	morph.InfoLogger.Printf("Attempting to apply  %d migrations...\n", steps)
-	n, err := apply.Down(ctx, steps, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
+	n, err := apply.Down(ctx, steps, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetStatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey))
 	if n > 0 {
 		morph.SuccessLogger.Printf("%d migrations applied.\n", n)
 	} else if n == 0 {
@@ -122,7 +122,7 @@ func migrateApplyCmdF(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	morph.InfoLogger.Println("Applying all pending migrations...")
-	if err := apply.Migrate(ctx, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetSatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey)); err != nil {
+	if err := apply.Migrate(ctx, dsn, driverName, path, morph.SetMigrationTableName(tableName), morph.SetStatementTimeoutInSeconds(timeout), morph.WithLock(mutexKey)); err != nil {
 		return err
 	}
 	morph.SuccessLogger.Println("Pending migrations applied.")

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -150,15 +150,7 @@ func (driver *mysql) createSchemaTableIfNotExists() (err error) {
 }
 
 func (driver *mysql) Apply(migration *models.Migration, saveVersion bool) (err error) {
-	query, readErr := migration.Query()
-	if readErr != nil {
-		return &drivers.AppError{
-			OrigErr: readErr,
-			Driver:  driverName,
-			Message: fmt.Sprintf("failed to read migration query: %s", migration.Name),
-		}
-	}
-	defer migration.Close()
+	query := migration.Query()
 	ctx, cancel := drivers.GetContext(driver.config.StatementTimeoutInSecs)
 	defer cancel()
 

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -7,10 +7,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -239,7 +237,7 @@ func (suite *MysqlTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -252,7 +250,7 @@ func (suite *MysqlTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;\nselect 1;")),
+					Bytes:   []byte("select 1;\nselect 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -265,14 +263,14 @@ func (suite *MysqlTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 2,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_2.sql",
 				},
 			},
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -284,7 +282,7 @@ func (suite *MysqlTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select * from foobar;")),
+					Bytes:   []byte("select * from foobar;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -299,12 +297,12 @@ func (suite *MysqlTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 				{
 					Version: 2,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select * from foobar;")),
+					Bytes:   []byte("select * from foobar;"),
 					Name:    "migration_2.sql",
 				},
 			},

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -220,15 +220,7 @@ func (pg *postgres) Close() error {
 }
 
 func (pg *postgres) Apply(migration *models.Migration, saveVersion bool) (err error) {
-	query, readErr := migration.Query()
-	if readErr != nil {
-		return &drivers.AppError{
-			OrigErr: readErr,
-			Driver:  driverName,
-			Message: fmt.Sprintf("failed to read migration query: %s", migration.Name),
-		}
-	}
-	defer migration.Close()
+	query := migration.Query()
 
 	ctx, cancel := drivers.GetContext(pg.config.StatementTimeoutInSecs)
 	defer cancel()

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -7,10 +7,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -245,7 +243,7 @@ func (suite *PostgresTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -258,7 +256,7 @@ func (suite *PostgresTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;\nselect 1;")),
+					Bytes:   []byte("select 1;\nselect 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -271,14 +269,14 @@ func (suite *PostgresTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 2,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_2.sql",
 				},
 			},
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -290,7 +288,7 @@ func (suite *PostgresTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select * from foobar;")),
+					Bytes:   []byte("select * from foobar;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -305,12 +303,12 @@ func (suite *PostgresTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 				{
 					Version: 2,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select * from foobar;")),
+					Bytes:   []byte("select * from foobar;"),
 					Name:    "migration_2.sql",
 				},
 			},

--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -177,15 +177,8 @@ func (driver *sqlite) Apply(migration *models.Migration, saveVersion bool) (err 
 		_ = driver.unlock()
 	}()
 
-	query, readErr := migration.Query()
-	if readErr != nil {
-		return &drivers.AppError{
-			OrigErr: readErr,
-			Driver:  driverName,
-			Message: fmt.Sprintf("failed to read migration query: %s", migration.Name),
-		}
-	}
-	defer migration.Close()
+	query := migration.Query()
+
 	ctx, cancel := drivers.GetContext(driver.config.StatementTimeoutInSecs)
 	defer cancel()
 

--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/mattermost/morph/drivers"
@@ -200,7 +199,7 @@ func (suite *SqliteTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -213,7 +212,7 @@ func (suite *SqliteTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;\nselect 1;")),
+					Bytes:   []byte("select 1;\nselect 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -226,14 +225,14 @@ func (suite *SqliteTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 2,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_2.sql",
 				},
 			},
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -245,7 +244,7 @@ func (suite *SqliteTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select * from foobar;")),
+					Bytes:   []byte("select * from foobar;"),
 					Name:    "migration_1.sql",
 				},
 			},
@@ -260,12 +259,12 @@ func (suite *SqliteTestSuite) TestApply() {
 			[]*models.Migration{
 				{
 					Version: 1,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select 1;")),
+					Bytes:   []byte("select 1;"),
 					Name:    "migration_1.sql",
 				},
 				{
 					Version: 2,
-					Bytes:   ioutil.NopCloser(strings.NewReader("select * from foobar;")),
+					Bytes:   []byte("select * from foobar;"),
 					Name:    "migration_2.sql",
 				},
 			},

--- a/morph.go
+++ b/morph.go
@@ -60,7 +60,7 @@ func SetMigrationTableName(name string) EngineOption {
 	}
 }
 
-func SetSatementTimeoutInSeconds(n int) EngineOption {
+func SetStatementTimeoutInSeconds(n int) EngineOption {
 	return func(m *Morph) {
 		_ = m.driver.SetConfig("StatementTimeoutInSecs", n)
 	}
@@ -161,7 +161,7 @@ func (m *Morph) Apply(limit int) (int, error) {
 
 	steps := limit
 	if len(migrations) < steps {
-		return -1, fmt.Errorf("there are only %d migrations avaliable, but you requested %d", len(migrations), steps)
+		return -1, fmt.Errorf("there are only %d migrations available, but you requested %d", len(migrations), steps)
 	}
 
 	if limit < 0 {
@@ -201,7 +201,7 @@ func (m *Morph) ApplyDown(limit int) (int, error) {
 
 	steps := limit
 	if len(sortedMigrations) < steps {
-		return -1, fmt.Errorf("there are only %d migrations avaliable, but you requested %d", len(sortedMigrations), steps)
+		return -1, fmt.Errorf("there are only %d migrations available, but you requested %d", len(sortedMigrations), steps)
 	}
 
 	if limit < 0 {

--- a/sources/testlib/testing.go
+++ b/sources/testlib/testing.go
@@ -5,7 +5,6 @@ package testlib
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/mattermost/morph/sources"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func checkMigrations(t *testing.T, migrations []*models.Migration) {
@@ -22,9 +20,7 @@ func checkMigrations(t *testing.T, migrations []*models.Migration) {
 		for _, migration := range migrations {
 			if strings.Contains(migration.Name, fmt.Sprintf("migration_%d", i)) {
 				migrationExists = true
-				b, err := ioutil.ReadAll(migration.Bytes)
-				require.NoError(t, err)
-				assert.Contains(t, string(b), fmt.Sprintf("migration%d", i))
+				assert.Contains(t, string(migration.Bytes), fmt.Sprintf("migration%d", i))
 			}
 		}
 		assert.Truef(t, migrationExists, "Migration %d was not found in source", i)


### PR DESCRIPTION
#### Summary
We read the migration files only once and store in memory. As an alternative approach for this PR; Rather than storing the contents of the migration as `[]byte` we can use `io.ReadSeeker`, but anyway all of the contents will be in the memory and not sure having the bytes wrapped in a reader bring much value for our specific case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46334
