### PR TITLE
PoC: Foundation adapter

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -1,6 +1,8 @@
 package drivers
 
 import (
+	"database/sql"
+
 	"github.com/mattermost/morph/models"
 )
 
@@ -20,4 +22,9 @@ type Driver interface {
 	Apply(migration *models.Migration, saveVersion bool) error
 	AppliedMigrations() ([]*models.Migration, error)
 	SetConfig(key string, value interface{}) error
+}
+
+type DBNamer interface {
+	DB() *sql.DB
+	Name() string
 }

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -333,3 +333,11 @@ func (driver *mysql) SetConfig(key string, value interface{}) error {
 
 	return fmt.Errorf("incorrect key name %q", key)
 }
+
+func (driver *mysql) DB() *sql.DB {
+	return driver.db
+}
+
+func (driver *mysql) Name() string {
+	return "mysql"
+}

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -390,3 +390,11 @@ func (pg *postgres) SetConfig(key string, value interface{}) error {
 
 	return fmt.Errorf("incorrect key name %q", key)
 }
+
+func (driver *postgres) DB() *sql.DB {
+	return driver.db
+}
+
+func (driver *postgres) Name() string {
+	return "postgres"
+}

--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -374,3 +374,11 @@ func execTransaction(transaction *sql.Tx, query string) error {
 
 	return nil
 }
+
+func (driver *sqlite) DB() *sql.DB {
+	return driver.db
+}
+
+func (driver *sqlite) Name() string {
+	return "sqlite"
+}

--- a/models/parse.go
+++ b/models/parse.go
@@ -18,6 +18,7 @@ var (
 )
 
 // Regex matches the following pattern:
-//  123_name.up.ext
-//  123_name.down.ext
+//
+//	123_name.up.ext
+//	123_name.down.ext
 var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,70 @@
+package morph
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/mattermost/morph/drivers"
+)
+
+// Migrator is a utility class for testing migrations. It can be used in Foundation testing
+// see https://github.com/mgdelacroix/foundation
+type Migrator struct {
+	db           *sql.DB
+	driverName   string
+	engine       *Morph
+	interceptors map[int]func() error
+}
+
+// New creates a new instance of the Migrator to test migrations.
+func NewMigrator(engine *Morph, interceptors map[int]func() error) *Migrator {
+	dn, ok := engine.driver.(drivers.DBNamer)
+	if !ok {
+		panic("driver does not implement DBNamer")
+	}
+
+	return &Migrator{
+		db:           dn.DB(),
+		driverName:   dn.Name(),
+		engine:       engine,
+		interceptors: interceptors,
+	}
+}
+
+func (m *Migrator) DB() *sql.DB {
+	return m.db
+}
+
+func (m *Migrator) DriverName() string {
+	return m.driverName
+}
+
+func (m *Migrator) Setup() error {
+	return nil
+}
+
+func (m *Migrator) MigrateToStep(step int) error {
+	migrations, err := m.engine.driver.AppliedMigrations()
+	if err != nil {
+		return err
+	}
+
+	if len(migrations) > step {
+		return fmt.Errorf("asked to migrate to step %d, but there are already %d migrations applied", step, len(migrations))
+	}
+
+	_, err = m.engine.Apply(step - len(migrations))
+	if err != nil {
+		return fmt.Errorf("failed to apply migrations: %s", err)
+	}
+
+	return nil
+}
+
+func (m *Migrator) Interceptors() map[int]func() error {
+	return m.interceptors
+}
+
+func (m *Migrator) TearDown() error {
+	return m.engine.Close()
+}


### PR DESCRIPTION
#### Summary
Add an easy way to create a Foundation `Migrator` interface so that this can be used for testing in mm-product projects!


