### PR TITLE
simplify the API by reducing any alternative approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ if err != nil {
 }
 defer src.Close()
 
-driver, err := mysql.WithInstance(db, &mysql.Config{})
+driver, err := mysql.WithInstance(db)
 if err != nil {
     return err
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -19,5 +19,10 @@ type Driver interface {
 	Close() error
 	Apply(migration *models.Migration, saveVersion bool) error
 	AppliedMigrations() ([]*models.Migration, error)
+	// SetConfig should be used to set the driver configuration. The key is the name of the configuration
+	// This method should return an error if the key is not supported.
+	// This method is being used by the morph engine to apply configurations such as:
+	// StatementTimeoutInSecs
+	// MigrationsTableName
 	SetConfig(key string, value interface{}) error
 }

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -257,22 +257,6 @@ func currentDatabaseNameFromDB(conn *sql.Conn, config *driverConfig) (string, er
 	return databaseName, nil
 }
 
-func mergeConfigs(config *driverConfig, defaultConfig *driverConfig) *driverConfig {
-	if config.MigrationsTable == "" {
-		config.MigrationsTable = defaultConfig.MigrationsTable
-	}
-
-	if config.StatementTimeoutInSecs == 0 {
-		config.StatementTimeoutInSecs = defaultConfig.StatementTimeoutInSecs
-	}
-
-	if config.MigrationMaxSize == 0 {
-		config.MigrationMaxSize = defaultConfig.MigrationMaxSize
-	}
-
-	return config
-}
-
 func mergeConfigWithParams(params map[string]string, config *driverConfig) (*driverConfig, error) {
 	var err error
 

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -24,7 +24,7 @@ var configParams = []string{
 	"x-statement-timeout",
 }
 
-type Config struct {
+type driverConfig struct {
 	drivers.Config
 	databaseName   string
 	closeDBonClose bool
@@ -33,11 +33,11 @@ type Config struct {
 type mysql struct {
 	conn   *sql.Conn
 	db     *sql.DB
-	config *Config
+	config *driverConfig
 }
 
-func WithInstance(dbInstance *sql.DB, config *Config) (drivers.Driver, error) {
-	driverConfig := mergeConfigs(config, getDefaultConfig())
+func WithInstance(dbInstance *sql.DB) (drivers.Driver, error) {
+	driverConfig := getDefaultConfig()
 
 	conn, err := dbInstance.Conn(context.Background())
 	if err != nil {
@@ -237,7 +237,7 @@ func (driver *mysql) AppliedMigrations() (migrations []*models.Migration, err er
 	return appliedMigrations, nil
 }
 
-func currentDatabaseNameFromDB(conn *sql.Conn, config *Config) (string, error) {
+func currentDatabaseNameFromDB(conn *sql.Conn, config *driverConfig) (string, error) {
 	query := "SELECT DATABASE()"
 
 	ctx, cancel := drivers.GetContext(config.StatementTimeoutInSecs)
@@ -257,7 +257,7 @@ func currentDatabaseNameFromDB(conn *sql.Conn, config *Config) (string, error) {
 	return databaseName, nil
 }
 
-func mergeConfigs(config *Config, defaultConfig *Config) *Config {
+func mergeConfigs(config *driverConfig, defaultConfig *driverConfig) *driverConfig {
 	if config.MigrationsTable == "" {
 		config.MigrationsTable = defaultConfig.MigrationsTable
 	}
@@ -273,7 +273,7 @@ func mergeConfigs(config *Config, defaultConfig *Config) *Config {
 	return config
 }
 
-func mergeConfigWithParams(params map[string]string, config *Config) (*Config, error) {
+func mergeConfigWithParams(params map[string]string, config *driverConfig) (*driverConfig, error) {
 	var err error
 
 	for _, configKey := range configParams {

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -101,7 +101,7 @@ func (suite *MysqlTestSuite) TestOpen() {
 		defer teardown()
 
 		defaultConfig := getDefaultConfig()
-		cfg := &Config{
+		cfg := &driverConfig{
 			Config: drivers.Config{
 				MigrationsTable:        defaultConfig.MigrationsTable,
 				StatementTimeoutInSecs: defaultConfig.StatementTimeoutInSecs,
@@ -110,6 +110,7 @@ func (suite *MysqlTestSuite) TestOpen() {
 			closeDBonClose: true, // we have created DB from DSN
 		}
 		mysqlDriver := connectedDriver.(*mysql)
+
 		suite.Assert().EqualValues(cfg, mysqlDriver.config)
 	})
 
@@ -368,17 +369,16 @@ func (suite *MysqlTestSuite) TestWithInstance() {
 	}()
 	suite.Assert().NoError(db.Ping(), "should not error when pinging the database")
 
-	config := &Config{
-		closeDBonClose: true,
-	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(db)
+	mysqlDriver := driver.(*mysql)
+	mysqlDriver.config.closeDBonClose = true
 	suite.Assert().NoError(err, "should not error when creating a driver from db instance")
 	defer func() {
 		err = driver.Close()
 		suite.Require().NoError(err, "should not error when closing the database connection")
 	}()
 
-	suite.Assert().Equal(databaseName, config.databaseName)
+	suite.Assert().Equal(databaseName, mysqlDriver.config.databaseName)
 }
 
 func TestMysqlTestSuite(t *testing.T) {

--- a/drivers/mysql/utils.go
+++ b/drivers/mysql/utils.go
@@ -23,11 +23,11 @@ func extractDatabaseNameFromURL(conn string) (string, error) {
 	return cfg.DBName, nil
 }
 
-func getDefaultConfig() *Config {
-	return &Config{
+func getDefaultConfig() *driverConfig {
+	return &driverConfig{
 		Config: drivers.Config{
 			MigrationsTable:        "db_migrations",
-			StatementTimeoutInSecs: 60,
+			StatementTimeoutInSecs: 300,
 			MigrationMaxSize:       defaultMigrationMaxSize,
 		},
 	}

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -143,22 +143,6 @@ func mergeConfigWithParams(params map[string]string, config *driverConfig) (*dri
 	return config, nil
 }
 
-func mergeConfigs(config, defaultConfig *driverConfig) *driverConfig {
-	if config.MigrationsTable == "" {
-		config.MigrationsTable = defaultConfig.MigrationsTable
-	}
-
-	if config.StatementTimeoutInSecs == 0 {
-		config.StatementTimeoutInSecs = defaultConfig.StatementTimeoutInSecs
-	}
-
-	if config.MigrationMaxSize == 0 {
-		config.MigrationMaxSize = defaultConfig.MigrationMaxSize
-	}
-
-	return config
-}
-
 func (pg *postgres) Ping() error {
 	ctx, cancel := drivers.GetContext(pg.config.StatementTimeoutInSecs)
 	defer cancel()

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -94,7 +94,7 @@ func (suite *PostgresTestSuite) TestOpen() {
 		defer teardown()
 
 		defaultConfig := getDefaultConfig()
-		cfg := &Config{
+		cfg := &driverConfig{
 			Config: drivers.Config{
 				MigrationsTable:        defaultConfig.MigrationsTable,
 				StatementTimeoutInSecs: defaultConfig.StatementTimeoutInSecs,
@@ -375,18 +375,17 @@ func (suite *PostgresTestSuite) TestWithInstance() {
 	}()
 	suite.Assert().NoError(db.Ping(), "should not error when pinging the database")
 
-	config := &Config{
-		closeDBonClose: true,
-	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(db)
+	psqlDriver := driver.(*postgres)
+	psqlDriver.config.closeDBonClose = true
 	suite.Assert().NoError(err, "should not error when creating a driver from db instance")
 	defer func() {
 		err = driver.Close()
 		suite.Require().NoError(err, "should not error when closing the database connection")
 	}()
 
-	suite.Assert().Equal(databaseName, config.databaseName)
-	suite.Assert().Equal("public", config.schemaName)
+	suite.Assert().Equal(databaseName, psqlDriver.config.databaseName)
+	suite.Assert().Equal("public", psqlDriver.config.schemaName)
 }
 
 func TestPostgresSuite(t *testing.T) {

--- a/drivers/postgres/utils.go
+++ b/drivers/postgres/utils.go
@@ -15,11 +15,11 @@ func extractDatabaseNameFromURL(URL string) (string, error) {
 	return uri.Path[1:], nil
 }
 
-func getDefaultConfig() *Config {
-	return &Config{
+func getDefaultConfig() *driverConfig {
+	return &driverConfig{
 		Config: drivers.Config{
 			MigrationsTable:        "db_migrations",
-			StatementTimeoutInSecs: 60,
+			StatementTimeoutInSecs: 300,
 			MigrationMaxSize:       defaultMigrationMaxSize,
 		},
 	}

--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -273,22 +273,6 @@ func (driver *sqlite) AppliedMigrations() (migrations []*models.Migration, err e
 	return appliedMigrations, nil
 }
 
-func mergeConfigs(config *driverConfig, defaultConfig *driverConfig) *driverConfig {
-	if config.MigrationsTable == "" {
-		config.MigrationsTable = defaultConfig.MigrationsTable
-	}
-
-	if config.StatementTimeoutInSecs == 0 {
-		config.StatementTimeoutInSecs = defaultConfig.StatementTimeoutInSecs
-	}
-
-	if config.MigrationMaxSize == 0 {
-		config.MigrationMaxSize = defaultConfig.MigrationMaxSize
-	}
-
-	return config
-}
-
 func mergeConfigWithParams(params map[string]string, config *driverConfig) (*driverConfig, error) {
 	var err error
 

--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -350,10 +350,10 @@ func (suite *SqliteTestSuite) TestWithInstance() {
 	}()
 	suite.Assert().NoError(db.Ping(), "should not error when pinging the database")
 
-	config := &Config{
-		closeDBonClose: true,
-	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(db)
+	sqliteDriver := driver.(*sqlite)
+	sqliteDriver.config.closeDBonClose = true
+
 	suite.Assert().NoError(err, "should not error when creating a driver from db instance")
 	defer func() {
 		err = driver.Close()

--- a/drivers/sqlite/utils.go
+++ b/drivers/sqlite/utils.go
@@ -2,11 +2,11 @@ package sqlite
 
 import "github.com/mattermost/morph/drivers"
 
-func getDefaultConfig() *Config {
-	return &Config{
+func getDefaultConfig() *driverConfig {
+	return &driverConfig{
 		Config: drivers.Config{
 			MigrationsTable:        "db_migrations",
-			StatementTimeoutInSecs: 60,
+			StatementTimeoutInSecs: 300,
 			MigrationMaxSize:       defaultMigrationMaxSize,
 		},
 	}

--- a/models/parse.go
+++ b/models/parse.go
@@ -18,6 +18,7 @@ var (
 )
 
 // Regex matches the following pattern:
-//  123_name.up.ext
-//  123_name.down.ext
+//
+//	123_name.up.ext
+//	123_name.down.ext
 var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)


### PR DESCRIPTION

#### Summary
I was reviewing the API after the initial implementation and realized that our configuration is confusing. Prior to this PR, we had two ways to set critical configuration values for `StatementTimeoutInSecs` and `MigrationsTable`, which either from driver config, or, using options in the morph engine. I think this duality creates confusion, or it can. To avoid that, it's better to keep this in one place.

Creating a driver with instance is now as easy as passing only `sql.DB` struct. The configuration for migrations should not be important for this stage hence dropped requiring the config. Semantically we are just initializing the driver.

To have some extra room on the initial query (getting the db name), `StatementTimeoutInSecs` for default driver config is increased to `300` seconds.

Also, the lock timeout option was not being used anywhere, we can rely on the `context.Context` passed to the engine on that. Added some documentation about that as well.

The only issue here is that, once the dependencies updated on mattermost-server and other repositories, we need to update these. I'll create the PRs once this gets merged.



