### PR TITLE
add initial test helper for the morph engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         image: postgres
         env:
           POSTGRES_PASSWORD: morph
+          POSTGRES_DB: morph_test
+          POSTGRES_USER: morph
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_PASSWORD: morph
+      POSTGRES_DB: morph_test
+      POSTGRES_USER: morph
   mysql:
     image: "mysql:5.7"
     restart: always

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -19,5 +19,10 @@ type Driver interface {
 	Close() error
 	Apply(migration *models.Migration, saveVersion bool) error
 	AppliedMigrations() ([]*models.Migration, error)
+	// SetConfig should be used to set the driver configuration. The key is the name of the configuration
+	// This method should return an error if the key is not supported.
+	// This method is being used by the morph engine to apply configurations such as:
+	// StatementTimeoutInSecs
+	// MigrationsTableName
 	SetConfig(key string, value interface{}) error
 }

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -257,22 +257,6 @@ func currentDatabaseNameFromDB(conn *sql.Conn, config *driverConfig) (string, er
 	return databaseName, nil
 }
 
-func mergeConfigs(config *driverConfig, defaultConfig *driverConfig) *driverConfig {
-	if config.MigrationsTable == "" {
-		config.MigrationsTable = defaultConfig.MigrationsTable
-	}
-
-	if config.StatementTimeoutInSecs == 0 {
-		config.StatementTimeoutInSecs = defaultConfig.StatementTimeoutInSecs
-	}
-
-	if config.MigrationMaxSize == 0 {
-		config.MigrationMaxSize = defaultConfig.MigrationMaxSize
-	}
-
-	return config
-}
-
 func mergeConfigWithParams(params map[string]string, config *driverConfig) (*driverConfig, error) {
 	var err error
 

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -24,7 +24,7 @@ var configParams = []string{
 	"x-statement-timeout",
 }
 
-type Config struct {
+type driverConfig struct {
 	drivers.Config
 	databaseName   string
 	closeDBonClose bool
@@ -33,11 +33,11 @@ type Config struct {
 type mysql struct {
 	conn   *sql.Conn
 	db     *sql.DB
-	config *Config
+	config *driverConfig
 }
 
-func WithInstance(dbInstance *sql.DB, config *Config) (drivers.Driver, error) {
-	driverConfig := mergeConfigs(config, getDefaultConfig())
+func WithInstance(dbInstance *sql.DB) (drivers.Driver, error) {
+	driverConfig := getDefaultConfig()
 
 	conn, err := dbInstance.Conn(context.Background())
 	if err != nil {
@@ -237,7 +237,7 @@ func (driver *mysql) AppliedMigrations() (migrations []*models.Migration, err er
 	return appliedMigrations, nil
 }
 
-func currentDatabaseNameFromDB(conn *sql.Conn, config *Config) (string, error) {
+func currentDatabaseNameFromDB(conn *sql.Conn, config *driverConfig) (string, error) {
 	query := "SELECT DATABASE()"
 
 	ctx, cancel := drivers.GetContext(config.StatementTimeoutInSecs)
@@ -257,7 +257,7 @@ func currentDatabaseNameFromDB(conn *sql.Conn, config *Config) (string, error) {
 	return databaseName, nil
 }
 
-func mergeConfigs(config *Config, defaultConfig *Config) *Config {
+func mergeConfigs(config *driverConfig, defaultConfig *driverConfig) *driverConfig {
 	if config.MigrationsTable == "" {
 		config.MigrationsTable = defaultConfig.MigrationsTable
 	}
@@ -273,7 +273,7 @@ func mergeConfigs(config *Config, defaultConfig *Config) *Config {
 	return config
 }
 
-func mergeConfigWithParams(params map[string]string, config *Config) (*Config, error) {
+func mergeConfigWithParams(params map[string]string, config *driverConfig) (*driverConfig, error) {
 	var err error
 
 	for _, configKey := range configParams {

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -61,6 +61,9 @@ func (suite *MysqlTestSuite) AfterTest(_, _ string) {
 	_, err := suite.db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", databaseName))
 	suite.Require().NoError(err, "should not error when dropping the test database")
 
+	_, err = suite.db.Exec(fmt.Sprintf("CREATE DATABASE %s", databaseName))
+	suite.Require().NoError(err, "should not error when creating the test database")
+
 	if suite.db != nil {
 		err := suite.db.Close()
 		suite.Require().NoError(err, "should not error when closing the default database connection")

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -101,7 +101,7 @@ func (suite *MysqlTestSuite) TestOpen() {
 		defer teardown()
 
 		defaultConfig := getDefaultConfig()
-		cfg := &Config{
+		cfg := &driverConfig{
 			Config: drivers.Config{
 				MigrationsTable:        defaultConfig.MigrationsTable,
 				StatementTimeoutInSecs: defaultConfig.StatementTimeoutInSecs,
@@ -110,6 +110,7 @@ func (suite *MysqlTestSuite) TestOpen() {
 			closeDBonClose: true, // we have created DB from DSN
 		}
 		mysqlDriver := connectedDriver.(*mysql)
+
 		suite.Assert().EqualValues(cfg, mysqlDriver.config)
 	})
 
@@ -368,17 +369,16 @@ func (suite *MysqlTestSuite) TestWithInstance() {
 	}()
 	suite.Assert().NoError(db.Ping(), "should not error when pinging the database")
 
-	config := &Config{
-		closeDBonClose: true,
-	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(db)
+	mysqlDriver := driver.(*mysql)
+	mysqlDriver.config.closeDBonClose = true
 	suite.Assert().NoError(err, "should not error when creating a driver from db instance")
 	defer func() {
 		err = driver.Close()
 		suite.Require().NoError(err, "should not error when closing the database connection")
 	}()
 
-	suite.Assert().Equal(databaseName, config.databaseName)
+	suite.Assert().Equal(databaseName, mysqlDriver.config.databaseName)
 }
 
 func TestMysqlTestSuite(t *testing.T) {

--- a/drivers/mysql/utils.go
+++ b/drivers/mysql/utils.go
@@ -23,11 +23,11 @@ func extractDatabaseNameFromURL(conn string) (string, error) {
 	return cfg.DBName, nil
 }
 
-func getDefaultConfig() *Config {
-	return &Config{
+func getDefaultConfig() *driverConfig {
+	return &driverConfig{
 		Config: drivers.Config{
 			MigrationsTable:        "db_migrations",
-			StatementTimeoutInSecs: 60,
+			StatementTimeoutInSecs: 300,
 			MigrationMaxSize:       defaultMigrationMaxSize,
 		},
 	}

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -143,22 +143,6 @@ func mergeConfigWithParams(params map[string]string, config *driverConfig) (*dri
 	return config, nil
 }
 
-func mergeConfigs(config, defaultConfig *driverConfig) *driverConfig {
-	if config.MigrationsTable == "" {
-		config.MigrationsTable = defaultConfig.MigrationsTable
-	}
-
-	if config.StatementTimeoutInSecs == 0 {
-		config.StatementTimeoutInSecs = defaultConfig.StatementTimeoutInSecs
-	}
-
-	if config.MigrationMaxSize == 0 {
-		config.MigrationMaxSize = defaultConfig.MigrationMaxSize
-	}
-
-	return config
-}
-
 func (pg *postgres) Ping() error {
 	ctx, cancel := drivers.GetContext(pg.config.StatementTimeoutInSecs)
 	defer cancel()

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -94,7 +94,7 @@ func (suite *PostgresTestSuite) TestOpen() {
 		defer teardown()
 
 		defaultConfig := getDefaultConfig()
-		cfg := &Config{
+		cfg := &driverConfig{
 			Config: drivers.Config{
 				MigrationsTable:        defaultConfig.MigrationsTable,
 				StatementTimeoutInSecs: defaultConfig.StatementTimeoutInSecs,
@@ -375,18 +375,17 @@ func (suite *PostgresTestSuite) TestWithInstance() {
 	}()
 	suite.Assert().NoError(db.Ping(), "should not error when pinging the database")
 
-	config := &Config{
-		closeDBonClose: true,
-	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(db)
+	psqlDriver := driver.(*postgres)
+	psqlDriver.config.closeDBonClose = true
 	suite.Assert().NoError(err, "should not error when creating a driver from db instance")
 	defer func() {
 		err = driver.Close()
 		suite.Require().NoError(err, "should not error when closing the database connection")
 	}()
 
-	suite.Assert().Equal(databaseName, config.databaseName)
-	suite.Assert().Equal("public", config.schemaName)
+	suite.Assert().Equal(databaseName, psqlDriver.config.databaseName)
+	suite.Assert().Equal("public", psqlDriver.config.schemaName)
 }
 
 func TestPostgresSuite(t *testing.T) {

--- a/drivers/postgres/utils.go
+++ b/drivers/postgres/utils.go
@@ -15,11 +15,11 @@ func extractDatabaseNameFromURL(URL string) (string, error) {
 	return uri.Path[1:], nil
 }
 
-func getDefaultConfig() *Config {
-	return &Config{
+func getDefaultConfig() *driverConfig {
+	return &driverConfig{
 		Config: drivers.Config{
 			MigrationsTable:        "db_migrations",
-			StatementTimeoutInSecs: 60,
+			StatementTimeoutInSecs: 300,
 			MigrationMaxSize:       defaultMigrationMaxSize,
 		},
 	}

--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -273,22 +273,6 @@ func (driver *sqlite) AppliedMigrations() (migrations []*models.Migration, err e
 	return appliedMigrations, nil
 }
 
-func mergeConfigs(config *driverConfig, defaultConfig *driverConfig) *driverConfig {
-	if config.MigrationsTable == "" {
-		config.MigrationsTable = defaultConfig.MigrationsTable
-	}
-
-	if config.StatementTimeoutInSecs == 0 {
-		config.StatementTimeoutInSecs = defaultConfig.StatementTimeoutInSecs
-	}
-
-	if config.MigrationMaxSize == 0 {
-		config.MigrationMaxSize = defaultConfig.MigrationMaxSize
-	}
-
-	return config
-}
-
 func mergeConfigWithParams(params map[string]string, config *driverConfig) (*driverConfig, error) {
 	var err error
 

--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -362,12 +361,12 @@ func (suite *SqliteTestSuite) TestWithInstance() {
 }
 
 func TestSqliteTestSuite(t *testing.T) {
-	defaultDBFile, err := ioutil.TempFile("", "morph-default.db")
+	defaultDBFile, err := os.CreateTemp("", "morph-default.db")
 	require.NoError(t, err)
 	info, err := defaultDBFile.Stat()
 	require.NoError(t, err)
 
-	testDBFile, err := ioutil.TempFile("", "morph-test.db")
+	testDBFile, err := os.CreateTemp("", "morph-test.db")
 	require.NoError(t, err)
 	tfInfo, err := testDBFile.Stat()
 	require.NoError(t, err)

--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -350,10 +350,10 @@ func (suite *SqliteTestSuite) TestWithInstance() {
 	}()
 	suite.Assert().NoError(db.Ping(), "should not error when pinging the database")
 
-	config := &Config{
-		closeDBonClose: true,
-	}
-	driver, err := WithInstance(db, config)
+	driver, err := WithInstance(db)
+	sqliteDriver := driver.(*sqlite)
+	sqliteDriver.config.closeDBonClose = true
+
 	suite.Assert().NoError(err, "should not error when creating a driver from db instance")
 	defer func() {
 		err = driver.Close()

--- a/drivers/sqlite/utils.go
+++ b/drivers/sqlite/utils.go
@@ -2,11 +2,11 @@ package sqlite
 
 import "github.com/mattermost/morph/drivers"
 
-func getDefaultConfig() *Config {
-	return &Config{
+func getDefaultConfig() *driverConfig {
+	return &driverConfig{
 		Config: drivers.Config{
 			MigrationsTable:        "db_migrations",
-			StatementTimeoutInSecs: 60,
+			StatementTimeoutInSecs: 300,
 			MigrationMaxSize:       defaultMigrationMaxSize,
 		},
 	}

--- a/models/parse.go
+++ b/models/parse.go
@@ -18,6 +18,7 @@ var (
 )
 
 // Regex matches the following pattern:
-//  123_name.up.ext
-//  123_name.down.ext
+//
+//	123_name.up.ext
+//	123_name.down.ext
 var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string(Up) + `)\.(.*)$`)

--- a/morph_test.go
+++ b/morph_test.go
@@ -1,3 +1,6 @@
+//go:build !drivers
+// +build !drivers
+
 package morph
 
 import (
@@ -6,6 +9,7 @@ import (
 	"github.com/mattermost/morph/models"
 
 	"github.com/stretchr/testify/assert"
+	_ "modernc.org/sqlite"
 )
 
 func TestSortMigrations(t *testing.T) {

--- a/sources/embedded/embedded.go
+++ b/sources/embedded/embedded.go
@@ -3,7 +3,7 @@ package embedded
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/mattermost/morph/models"
 	"github.com/mattermost/morph/sources"
@@ -40,7 +40,7 @@ func WithInstance(assetSource *AssetSource) (sources.Source, error) {
 			return nil, fmt.Errorf("cannot read migration %q: %w", filename, err)
 		}
 
-		m, err := models.NewMigration(ioutil.NopCloser(bytes.NewReader(migrationBytes)), filename)
+		m, err := models.NewMigration(io.NopCloser(bytes.NewReader(migrationBytes)), filename)
 		if err != nil {
 			return nil, fmt.Errorf("could not create migration: %w", err)
 		}

--- a/test_helper.go
+++ b/test_helper.go
@@ -1,3 +1,4 @@
+// nolint
 package morph
 
 import (

--- a/test_helper.go
+++ b/test_helper.go
@@ -1,0 +1,203 @@
+package morph
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/mattermost/morph/drivers"
+	"github.com/mattermost/morph/drivers/mysql"
+	"github.com/mattermost/morph/drivers/postgres"
+	"github.com/mattermost/morph/drivers/sqlite"
+	"github.com/mattermost/morph/models"
+	"github.com/mattermost/morph/sources"
+	"github.com/mattermost/morph/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	defaultPostgresDSN = "postgres://morph:morph@localhost/morph_test?sslmode=disable"
+	defaultMySQLDSN    = "morph:morph@tcp(127.0.0.1:3307)/morph_test?multiStatements=true"
+	defaultSQLiteDSN   = "file::memory:?cache=shared"
+)
+
+// query is a map of driver name to a map of direction for the dummy queries
+var queries = map[string]map[models.Direction]string{
+	"postgres": {
+		models.Up:   `CREATE TABLE IF NOT EXISTS {{.Name}} (id serial PRIMARY KEY, name text)`,
+		models.Down: `DROP TABLE IF EXISTS {{.Name}}`,
+	},
+	"mysql": {
+		models.Up:   `CREATE TABLE IF NOT EXISTS {{.Name}} (id int(11) NOT NULL AUTO_INCREMENT, name varchar(255), PRIMARY KEY (id))`,
+		models.Down: `DROP TABLE IF EXISTS {{.Name}}`,
+	},
+	"sqlite": {
+		models.Up:   `CREATE TABLE IF NOT EXISTS {{.Name}} (id integer PRIMARY KEY AUTOINCREMENT, name text)`,
+		models.Down: `DROP TABLE IF EXISTS {{.Name}}`,
+	},
+}
+
+// testHelper is a helper struct for testing morph engine.
+// It contains all the necessary information to run tests for all drivers.
+// It also provides helper functions to create dummy migrations.
+type testHelper struct {
+	drivers     map[string]drivers.Driver
+	dbInstances map[string]*sql.DB
+	sqliteFile  string
+	options     []EngineOption
+	migrations  map[string][]*models.Migration
+}
+
+// testSource is a dummy source for testing purposes.
+type testSource struct {
+	migrations []*models.Migration
+}
+
+func (s *testSource) Migrations() []*models.Migration {
+	return s.migrations
+}
+
+// source returns a dummy source for the given driver
+func (h *testHelper) source(driverName string) sources.Source {
+	src := &testSource{
+		migrations: h.migrations[driverName],
+	}
+
+	return src
+}
+
+func newTestHelper(t *testing.T, options ...EngineOption) *testHelper {
+	helper := &testHelper{
+		options:     options,
+		drivers:     map[string]drivers.Driver{},
+		migrations:  map[string][]*models.Migration{},
+		dbInstances: map[string]*sql.DB{},
+	}
+
+	helper.initializeDrivers(t)
+
+	return helper
+}
+
+func (h *testHelper) CreateBasicMigrations(t *testing.T) {
+	h.AddMigration(t, "create_table_1")
+	h.AddMigration(t, "create_table_2")
+	h.AddMigration(t, "create_table_3")
+}
+
+// AddMigration adds a dummy migration to the test helper. It is important to add
+// migrations before running the RunForAllDrivers function as migrations are registered
+// before the test function is run.
+func (h *testHelper) AddMigration(t *testing.T, migrationName string) {
+	// Just generate a random name
+	tableName := fmt.Sprintf("test_%s_%d", migrationName, time.Now().Unix())
+	for name := range h.drivers {
+		v := 1 + uint32(len(h.migrations[name]))
+		h.migrations[name] = append(h.migrations[name], &models.Migration{
+			Name:      migrationName,
+			Direction: models.Up,
+			Version:   v,
+			Bytes:     getMigration(t, name, models.Up, tableName),
+			RawName:   fmt.Sprintf("%d_%s.up.sql", v, migrationName),
+		})
+		h.migrations[name] = append(h.migrations[name], &models.Migration{
+			Name:      migrationName,
+			Direction: models.Down,
+			Version:   v,
+			Bytes:     getMigration(t, name, models.Down, tableName),
+			RawName:   fmt.Sprintf("%d_%s.down.sql", v, migrationName),
+		})
+	}
+}
+
+// getMigration returns a dummy migration for the given driver and direction
+func getMigration(t *testing.T, driver string, direction models.Direction, tableName string) []byte {
+	tmp, err := template.New("query").Parse(queries[driver][direction])
+	require.NoError(t, err)
+
+	var b bytes.Buffer
+	err = tmp.Execute(&b, struct{ Name string }{Name: tableName})
+	require.NoError(t, err)
+
+	return b.Bytes()
+}
+
+// RunForAllDrivers runs the given test function for all drivers of the test helper
+func (h *testHelper) RunForAllDrivers(t *testing.T, f func(*testing.T, *Morph), name ...string) {
+	var testName string
+	if len(name) > 0 {
+		testName = name[0] + "/"
+	}
+
+	for name, driver := range h.drivers {
+		t.Run(testName+name, func(t *testing.T) {
+			engine, err := New(context.Background(), driver, h.source(name), h.options...)
+			require.NoError(t, err)
+
+			f(t, engine)
+		})
+	}
+}
+
+// TearDown closes all database connections and removes all tables from the databases
+func (h *testHelper) Teardown(t *testing.T) {
+	assets := testlib.Assets()
+	for name, driver := range h.drivers {
+		b, err := assets.ReadFile(filepath.Join("scripts", name+"_drop_all_tables.sql"))
+		require.NoError(t, err)
+		migration := &models.Migration{
+			Bytes: b,
+		}
+		err = driver.Apply(migration, false)
+		require.NoError(t, err)
+	}
+
+	for _, instance := range h.dbInstances {
+		err := instance.Close()
+		require.NoError(t, err)
+	}
+
+	err := os.RemoveAll(h.sqliteFile)
+	require.NoError(t, err)
+}
+
+func (h *testHelper) initializeDrivers(t *testing.T) {
+	// postgres
+	db, err := sql.Open("postgres", defaultPostgresDSN)
+	require.NoError(t, err)
+
+	pgDriver, err := postgres.WithInstance(db)
+	require.NoError(t, err)
+	h.drivers["postgres"] = pgDriver
+	h.dbInstances["postgres"] = db
+
+	// mysql
+	db2, err := sql.Open("mysql", defaultMySQLDSN)
+	require.NoError(t, err)
+
+	mysqlDriver, err := mysql.WithInstance(db2)
+	require.NoError(t, err)
+	h.drivers["mysql"] = mysqlDriver
+	h.dbInstances["mysql"] = db2
+
+	// sqlite
+	testDBFile, err := os.CreateTemp("", "morph-test.db")
+	require.NoError(t, err)
+	tfInfo, err := testDBFile.Stat()
+	require.NoError(t, err)
+	h.sqliteFile = filepath.Join(os.TempDir(), tfInfo.Name())
+
+	db3, err := sql.Open("sqlite", h.sqliteFile)
+	require.NoError(t, err)
+
+	sqliteDriver, err := sqlite.WithInstance(db3)
+	require.NoError(t, err)
+	h.drivers["sqlite"] = sqliteDriver
+	h.dbInstances["sqlite"] = db3
+}

--- a/testlib/assets.go
+++ b/testlib/assets.go
@@ -1,0 +1,10 @@
+package testlib
+
+import "embed"
+
+//go:embed scripts
+var assets embed.FS
+
+func Assets() embed.FS {
+	return assets
+}

--- a/testlib/scripts/mysql_drop_all_tables.sql
+++ b/testlib/scripts/mysql_drop_all_tables.sql
@@ -1,0 +1,34 @@
+DROP PROCEDURE IF EXISTS drop_all_tables;
+
+CREATE PROCEDURE drop_all_tables()
+BEGIN
+    DECLARE _done INT DEFAULT FALSE;
+    DECLARE _tableName VARCHAR(255);
+    DECLARE _cursor CURSOR FOR
+        SELECT table_name 
+        FROM information_schema.TABLES
+        WHERE table_schema = SCHEMA();
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET _done = TRUE;
+
+    SET FOREIGN_KEY_CHECKS = 0;
+
+    OPEN _cursor;
+
+    REPEAT FETCH _cursor INTO _tableName;
+
+    IF NOT _done THEN
+        SET @stmt_sql = CONCAT('DROP TABLE ', _tableName);
+        PREPARE stmt1 FROM @stmt_sql;
+        EXECUTE stmt1;
+        DEALLOCATE PREPARE stmt1;
+    END IF;
+
+    UNTIL _done END REPEAT;
+
+    CLOSE _cursor;
+    SET FOREIGN_KEY_CHECKS = 1;
+END;
+
+call drop_all_tables(); 
+
+DROP PROCEDURE IF EXISTS drop_all_tables;

--- a/testlib/scripts/postgres_drop_all_tables.sql
+++ b/testlib/scripts/postgres_drop_all_tables.sql
@@ -1,0 +1,7 @@
+DO $$ DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP
+        EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
+    END LOOP;
+END $$;

--- a/testlib/scripts/sqlite_drop_all_tables.sql
+++ b/testlib/scripts/sqlite_drop_all_tables.sql
@@ -1,0 +1,5 @@
+PRAGMA writable_schema = 1;
+delete from sqlite_master where type in ('table', 'index', 'trigger');
+PRAGMA writable_schema = 0;
+
+PRAGMA INTEGRITY_CHECK;


### PR DESCRIPTION

#### Summary
This is the initial version of the test helper for the morph engine. We were testing the drivers but never tested morph engine as a black box. This helper should give access to test the engine.

Since the creation of the morph engine is pretty straightforward, that step is handled within the helper. `RunForAllDrivers` will run the given function for all added drivers with real databases. 

The helper probably evolve in time, I think this is a good start anyway. I'll add actual tests after this one, wanted to get some early feedback.

A possible test would look like:
```Go
func TestApplyAll(t *testing.T) {
	h := newTestHelper(t)
	defer h.Teardown(t)

	h.AddMigration(t, "test_migration")

	h.RunForAllDrivers(t, func(t *testing.T, engine *Morph) {
		err := engine.ApplyAll()
		require.NoError(t, err)

		migrations, err := engine.driver.AppliedMigrations()
		require.NoError(t, err)

		require.Len(t, migrations, 1)
	})
}
```

PS: you'll need to run `docker-compose up` to actually test with this.