### PR TITLE
[MM-51811]Add fail scenario for mysql version saving issue

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.50.1
+          version: v1.52.1
 
           # Optional: if set to true then the action will use pre-installed Go.
           skip-go-installation: true

--- a/drivers/lock.go
+++ b/drivers/lock.go
@@ -57,7 +57,7 @@ func NextWaitInterval(lastWaitInterval time.Duration, err error) time.Duration {
 	}
 
 	// Add some jitter to avoid unnecessary collision between competing other instances.
-	nextWaitInterval += time.Duration(rand.Int63n(int64(jitterWaitInterval)) - int64(jitterWaitInterval)/2)
+	nextWaitInterval -= time.Duration(rand.Int63n(int64(jitterWaitInterval) / 2))
 
 	return nextWaitInterval
 }

--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -18,8 +18,8 @@ import (
 //
 // A Mutex must not be copied after first use.
 type Mutex struct {
-	noCopy
-	key string
+	noCopy // nolint:unused
+	key    string
 
 	// lock guards the variables used to manage the refresh task, and is not itself related to
 	// the db lock.
@@ -256,7 +256,7 @@ func (m *Mutex) finalizeTx(tx *sql.Tx) {
 //
 // See https://golang.org/issues/8005#issuecomment-190753527
 // for details.
-type noCopy struct{}
+type noCopy struct{} // nolint:unused
 
 // Lock is a no-op used by -copylocks checker from `go vet`.
-func (*noCopy) Lock() {}
+func (*noCopy) Lock() {} // nolint:unused

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -172,7 +172,8 @@ func (driver *mysql) Apply(migration *models.Migration, saveVersion bool) (err e
 	}
 
 	updateVersionQuery := driver.addMigrationQuery(migration)
-	if res, err := driver.conn.ExecContext(updateVersionContext, updateVersionQuery); err != nil {
+	res, err := driver.conn.ExecContext(updateVersionContext, updateVersionQuery)
+	if err != nil {
 		return &drivers.DatabaseError{
 			OrigErr: err,
 			Driver:  driverName,
@@ -180,25 +181,25 @@ func (driver *mysql) Apply(migration *models.Migration, saveVersion bool) (err e
 			Command: "update_version",
 			Query:   []byte(updateVersionQuery),
 		}
-	} else if res != nil {
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return &drivers.DatabaseError{
-				OrigErr: err,
-				Driver:  driverName,
-				Message: "failed when reading the result for migrations table with the new version",
-				Command: "update_version",
-				Query:   []byte(updateVersionQuery),
-			}
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return &drivers.DatabaseError{
+			OrigErr: err,
+			Driver:  driverName,
+			Message: "failed when reading the result for migrations table with the new version",
+			Command: "update_version",
+			Query:   []byte(updateVersionQuery),
 		}
-		if affected == 0 {
-			return &drivers.DatabaseError{
-				OrigErr: sql.ErrNoRows,
-				Driver:  driverName,
-				Message: "could not update version, probably a version mismatch",
-				Command: "update_version",
-				Query:   []byte(updateVersionQuery),
-			}
+	}
+	if affected == 0 {
+		return &drivers.DatabaseError{
+			OrigErr: sql.ErrNoRows,
+			Driver:  driverName,
+			Message: "could not update version, probably a version mismatch",
+			Command: "update_version",
+			Query:   []byte(updateVersionQuery),
 		}
 	}
 

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -172,13 +172,33 @@ func (driver *mysql) Apply(migration *models.Migration, saveVersion bool) (err e
 	}
 
 	updateVersionQuery := driver.addMigrationQuery(migration)
-	if _, err := driver.conn.ExecContext(updateVersionContext, updateVersionQuery); err != nil {
+	if res, err := driver.conn.ExecContext(updateVersionContext, updateVersionQuery); err != nil {
 		return &drivers.DatabaseError{
 			OrigErr: err,
 			Driver:  driverName,
 			Message: "failed when updating migrations table with the new version",
 			Command: "update_version",
 			Query:   []byte(updateVersionQuery),
+		}
+	} else if res != nil {
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return &drivers.DatabaseError{
+				OrigErr: err,
+				Driver:  driverName,
+				Message: "failed when reading the result for migrations table with the new version",
+				Command: "update_version",
+				Query:   []byte(updateVersionQuery),
+			}
+		}
+		if affected == 0 {
+			return &drivers.DatabaseError{
+				OrigErr: sql.ErrNoRows,
+				Driver:  driverName,
+				Message: "could not update version, probably a version mismatch",
+				Command: "update_version",
+				Query:   []byte(updateVersionQuery),
+			}
 		}
 	}
 

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -18,8 +18,8 @@ import (
 //
 // A Mutex must not be copied after first use.
 type Mutex struct {
-	noCopy
-	key string
+	noCopy // nolint:unused
+	key    string
 
 	// lock guards the variables used to manage the refresh task, and is not itself related to
 	// the db lock.
@@ -256,7 +256,7 @@ func (m *Mutex) finalizeTx(tx *sql.Tx) {
 //
 // See https://golang.org/issues/8005#issuecomment-190753527
 // for details.
-type noCopy struct{}
+type noCopy struct{} // nolint:unused
 
 // Lock is a no-op used by -copylocks checker from `go vet`.
-func (*noCopy) Lock() {}
+func (*noCopy) Lock() {} // nolint:unused

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -452,7 +452,7 @@ func (suite *PostgresTestSuite) TestLock() {
 			suite.Require().NoError(err, "should not error while locking the mutex")
 
 			// ensure we waited the lock to be expire
-			suite.Require().True(time.Now().After(now.Add(2 * time.Second)))
+			suite.Require().True(time.Now().After(now.Add(1 * time.Second)))
 
 			err = mx.Unlock()
 			suite.Require().NoError(err, "should not error while unlocking the mutex")


### PR DESCRIPTION
#### Summary
When we are trying to delete a version from the migations table during a downgrade, if the version and name could not be found in the migrations table, we silently ignore this fact. This is not an issue for postgres and sqlite since we are already taking care of this in the same transaction with the DDL.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51811

