### PR TITLE
[MM-52417] add min args for plan apply

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -84,6 +84,7 @@ func PlanApplyCmd() *cobra.Command {
 		RunE:          planApplyCmdF,
 		SilenceUsage:  true,
 		SilenceErrors: false,
+		Args:          cobra.MinimumNArgs(1),
 	}
 	cmd.Flags().Bool("revert", false, "reverts an existing plan")
 


### PR DESCRIPTION

#### Summary
The plan should be always given as an argument to the `morph apply plan` command.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52417
