### PR TITLE
fix example for command's help

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -53,7 +53,7 @@ func NewScriptCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "script <file name>",
 		Short:   "Generates new migration files",
-		Example: "morph new script create_users --driver postgresql --dir db/migrations --timestamp",
+		Example: "morph new script create_users --driver postgres --dir db/migrations --timestamp",
 		Args:    cobra.ExactArgs(1),
 		Run:     generateScriptCmdF,
 	}
@@ -89,7 +89,7 @@ func NewPlanCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "plan <file name>",
 		Short:   "Generates new plan for the migration files with revert steps",
-		Example: "morph new plan plan --driver postgresql --dsn postgres://localhost:5432/morph --path db/migrations",
+		Example: "morph new plan plan --driver postgres --dsn postgres://localhost:5432/morph --path db/migrations",
 		Args:    cobra.ExactArgs(1),
 		Run:     generatePlanCmdF,
 	}


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Small fix on command's help regarding the name of the driver 'postgres' vs 'postgresql'. [#39](https://github.com/go-morph/morph/pull/39) changed from postgresql to postgres, however the command's help was not updated. New users are following the command's help so we're obtaining [.txt files](https://github.com/mattermost/morph/blob/e76e25978d56b44a94f8b52e5c103ba076483da1/commands/new.go#L362) because the name of the driver is not correct.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Don't have one.

