### PR TITLE
fix --timezone default value

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -61,7 +61,7 @@ func NewScriptCmd() *cobra.Command {
 	cmd.Flags().StringP("driver", "d", "", "the driver to use.")
 	cmd.Flags().BoolP("timestamp", "t", false, "a timestamp prefix will be added to migration file if set.")
 	cmd.Flags().StringP("timeformat", "f", "unix", "timestamp format to be used for timestamps.")
-	cmd.Flags().StringP("timezone", "z", "utc", "time zone to be used for timestamps.")
+	cmd.Flags().StringP("timezone", "z", "UTC", "time zone to be used for timestamps.")
 	cmd.Flags().BoolP("sequence", "s", false, "a sequence number prefix will be added to migration file if set.")
 	_ = cmd.MarkFlagRequired("driver")
 
@@ -78,7 +78,7 @@ func NewGenerateCmd() *cobra.Command {
 	cmd.Flags().StringP("driver", "d", "", "the driver to use.")
 	cmd.Flags().BoolP("timestamp", "t", false, "a timestamp prefix will be added to migration file if set.")
 	cmd.Flags().StringP("timeformat", "f", "unix", "timestamp format to be used for timestamps.")
-	cmd.Flags().StringP("timezone", "z", "utc", "time zone to be used for timestamps.")
+	cmd.Flags().StringP("timezone", "z", "UTC", "time zone to be used for timestamps.")
 	cmd.Flags().BoolP("sequence", "s", false, "a sequence number prefix will be added to migration file if set.")
 	_ = cmd.MarkFlagRequired("driver")
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
--timezone was using as a default value "utc" however the [expected value for LoadLocation](https://github.com/golang/go/blob/f09db2bb9331f4b31afb867173b1773e6494af27/src/time/zoneinfo.go#L667) was in uppercase. LoadLocation is being called [here](https://github.com/mattermost/morph/blob/e76e25978d56b44a94f8b52e5c103ba076483da1/commands/new.go#L252) from morph.

Without this patch, the following command is returning an error.
```
$ morph new script example --driver postgresql --dir db/migrations --timestamp
unknown time zone utc
$ morph new script example --driver postgresql --dir db/migrations --timestamp --timezone UTC
(works, no output is returned)
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Don't have one.

