### PR TITLE
MM-56321: Improve logging on lock acquisition failure

### DIFF
--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -84,6 +84,8 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 		err2 := m.releaseLock(ctx, now)
 		if err2 == nil { // lock has been released due to expiration
 			return true, nil
+		} else {
+			m.logger.Printf("Failed to release lock: %v", err2)
 		}
 
 		return false, fmt.Errorf("failed to lock mutex: %w", err)
@@ -181,6 +183,7 @@ func (m *Mutex) Lock(ctx context.Context) error {
 
 		ok, err := m.tryLock(ctx)
 		if err != nil || !ok {
+			m.logger.Printf("Failed to acquire lock. Trying again: %v\n", err)
 			waitInterval = drivers.NextWaitInterval(waitInterval, err)
 			continue
 		}

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -84,6 +84,8 @@ func (m *Mutex) tryLock(ctx context.Context) (bool, error) {
 		err2 := m.releaseLock(ctx, now)
 		if err2 == nil { // lock has been released due to expiration
 			return true, nil
+		} else {
+			m.logger.Printf("Failed to release lock: %v", err2)
 		}
 
 		return false, fmt.Errorf("failed to lock mutex: %w", err)
@@ -181,6 +183,7 @@ func (m *Mutex) Lock(ctx context.Context) error {
 
 		ok, err := m.tryLock(ctx)
 		if err != nil || !ok {
+			m.logger.Printf("Failed to acquire lock. Trying again: %v\n", err)
 			waitInterval = drivers.NextWaitInterval(waitInterval, err)
 			continue
 		}


### PR DESCRIPTION
Sometimes, we observe that the line "lock.go:80: DB is locked, going to try acquire the lock if it is expired."
appears in a loop and it never proceeds. (Internal ref: ZD-42529)

There is a bug somewhere in morph due to which we are unable to release the lock automatically.
The only solution remains to manually remove the row from the db_lock table which is not ideal.

We need to find the bug, but without logging the actual error we would never know. So logging
the error is the first step.

https://mattermost.atlassian.net/browse/MM-56321
