### PR TITLE
re-implement Lockable interface to drop requirement on driver impls.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.22.x]
 
     services:
       postgres:
@@ -58,5 +58,4 @@ jobs:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     - name: Execute Tests
       run: |                                # we run driver and rest tests at the same time
-        go get -d -t ./...
         make test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.52.1
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
+          version: v1.61.0

--- a/drivers/lock.go
+++ b/drivers/lock.go
@@ -73,7 +73,7 @@ type Locker interface {
 }
 
 type Lockable interface {
-	DriverName() string
+	NewMutex(key string, logger Logger) (Locker, error)
 }
 
 // IsLockable returns whether the given instance satisfies

--- a/drivers/mysql/lock.go
+++ b/drivers/mysql/lock.go
@@ -34,7 +34,7 @@ type Mutex struct {
 // NewMutex creates a mutex with the given key name.
 //
 // returns error if key is empty.
-func NewMutex(key string, driver drivers.Driver, logger drivers.Logger) (*Mutex, error) {
+func (driver *MySQL) NewMutex(key string, logger drivers.Logger) (*Mutex, error) {
 	key, err := drivers.MakeLockKey(key)
 	if err != nil {
 		return nil, err
@@ -43,12 +43,7 @@ func NewMutex(key string, driver drivers.Driver, logger drivers.Logger) (*Mutex,
 	ctx, cancel := context.WithTimeout(context.Background(), drivers.TTL)
 	defer cancel()
 
-	ms, ok := driver.(*mysql)
-	if !ok {
-		return nil, errors.New("incorrect implementation of the driver")
-	}
-
-	conn, err := ms.db.Conn(context.Background())
+	conn, err := driver.db.Conn(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/postgres/lock.go
+++ b/drivers/postgres/lock.go
@@ -34,7 +34,7 @@ type Mutex struct {
 // NewMutex creates a mutex with the given key name.
 //
 // returns error if key is empty.
-func NewMutex(key string, driver drivers.Driver, logger drivers.Logger) (*Mutex, error) {
+func (pg *Postgres) NewMutex(key string, logger drivers.Logger) (*Mutex, error) {
 	key, err := drivers.MakeLockKey(key)
 	if err != nil {
 		return nil, err
@@ -43,12 +43,7 @@ func NewMutex(key string, driver drivers.Driver, logger drivers.Logger) (*Mutex,
 	ctx, cancel := context.WithTimeout(context.Background(), drivers.TTL)
 	defer cancel()
 
-	ps, ok := driver.(*postgres)
-	if !ok {
-		return nil, errors.New("incorrect implementation of the driver")
-	}
-
-	conn, err := ps.db.Conn(context.Background())
+	conn, err := pg.db.Conn(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/morph
 
-go 1.19
+go 1.22
 
 require (
 	github.com/dave/jennifer v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
+github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -360,7 +361,9 @@ modernc.org/sqlite v1.18.0/go.mod h1:B9fRWZacNxJBHoCJZQr1R54zhVn3fjfl0aszflrTSxY
 modernc.org/strutil v1.1.1 h1:xv+J1BXY3Opl2ALrBwyfEikFAj8pmqcpnfmuwUwcozs=
 modernc.org/strutil v1.1.1/go.mod h1:DE+MQQ/hjKBZS2zNInV5hhcipt5rLPWkmpbGeW5mmdw=
 modernc.org/tcl v1.13.1 h1:npxzTwFTZYM8ghWicVIX1cRWzj7Nd8i6AqqX2p+IYao=
+modernc.org/tcl v1.13.1/go.mod h1:XOLfOwzhkljL4itZkK6T72ckMgvj0BDsnKNdZVUOecw=
 modernc.org/token v1.0.0 h1:a0jaWiNMDhDUtqOj09wvjWWAqd3q7WpBulmL9H2egsk=
 modernc.org/token v1.0.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/z v1.5.1 h1:RTNHdsrOpeoSeOF4FbzTo8gBYByaJ5xT7NgZ9ZqRiJM=
+modernc.org/z v1.5.1/go.mod h1:eWFB510QWW5Th9YGZT81s+LwvaAs3Q2yr4sP0rmLkv8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/morph.go
+++ b/morph.go
@@ -16,9 +16,6 @@ import (
 	"github.com/mattermost/morph/drivers"
 	"github.com/mattermost/morph/sources"
 
-	ms "github.com/mattermost/morph/drivers/mysql"
-	ps "github.com/mattermost/morph/drivers/postgres"
-
 	_ "github.com/mattermost/morph/sources/embedded"
 	_ "github.com/mattermost/morph/sources/file"
 )
@@ -118,16 +115,7 @@ func New(ctx context.Context, driver drivers.Driver, source sources.Source, opti
 	}
 
 	if impl, ok := driver.(drivers.Lockable); ok && engine.config.LockKey != "" {
-		var mx drivers.Locker
-		var err error
-		switch impl.DriverName() {
-		case "mysql":
-			mx, err = ms.NewMutex(engine.config.LockKey, driver, engine.config.Logger)
-		case "postgres":
-			mx, err = ps.NewMutex(engine.config.LockKey, driver, engine.config.Logger)
-		default:
-			err = errors.New("driver does not support locking")
-		}
+		mx, err := impl.NewMutex(engine.config.LockKey, engine.config.Logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Summary

This just bugged me. First of all, we should always return concrete types, this was just a remnant from initial implementation. No need to carry on. Apart from that, we are expecting driver itself to implement `Lockable` interface that returns an actual `Locker` interface.

We still support drivers can do Lock and can't. Even though there shouldn't be a code change required, this can be targeted for `v2`.
